### PR TITLE
[Feature] Add Beam Search as decoding strategy

### DIFF
--- a/notebooks/tutorials/7-decoding-strategies.ipynb
+++ b/notebooks/tutorials/7-decoding-strategies.ipynb
@@ -1,0 +1,324 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5f35f43a-a799-4e5b-8c6b-51e08932b61b",
+   "metadata": {},
+   "source": [
+    "# RL4CO Decoding Strategies Notebook\n",
+    "\n",
+    "This notebook demonstrates how to utilize the different decoding strategies available in rl4co/models/nn/dec_strategies.py during the different phases of model development. We will also demonstrate how to evaluate the model for different decoding strategies on the test dataset. \n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/ai4co/rl4co/blob/main/notebooks/tutorials/7-decoding-strategies.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "866f4981-7358-4086-9044-6df6a4ba8fea",
+   "metadata": {},
+   "source": [
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7538da3e-67df-4c72-9acb-345a3bc9fba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Uncomment the following line to install the package from PyPI\n",
+    "## You may need to restart the runtime in Colab after this\n",
+    "## Remember to choose a GPU runtime for faster training!\n",
+    "\n",
+    "# !pip install rl4co"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4380f62f-bde8-4fc5-aa1a-072d5be58a32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "from rl4co.envs import TSPEnv\n",
+    "from rl4co.models.zoo import AttentionModel, AttentionModelPolicy\n",
+    "from rl4co.utils.trainer import RL4COTrainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "566e2f04-0576-4789-ac25-706ef3ebb7ca",
+   "metadata": {},
+   "source": [
+    "### Setup Policy and Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40c9a2ac-a2cc-4a90-a810-75a092fa4890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# RL4CO env based on TorchRL\n",
+    "env = TSPEnv(num_loc=10) \n",
+    "\n",
+    "# Policy: neural network, in this case with encoder-decoder architecture\n",
+    "policy = AttentionModelPolicy(env.name, \n",
+    "                              embedding_dim=128,\n",
+    "                              num_encoder_layers=3,\n",
+    "                              num_heads=8,\n",
+    "                            )\n",
+    "\n",
+    "# Model: default is AM with REINFORCE and greedy rollout baseline\n",
+    "model = AttentionModel(env, \n",
+    "                       baseline=\"rollout\",\n",
+    "                       batch_size = 128,\n",
+    "                       val_batch_size = 512,\n",
+    "                       test_batch_size = 512,\n",
+    "                       train_data_size=1_00,\n",
+    "                       val_data_size=1_000,\n",
+    "                       test_data_size=1_000,\n",
+    "                       optimizer_kwargs={\"lr\": 1e-4},\n",
+    "                       policy_kwargs={  # we can specify the decode types using the policy_kwargs\n",
+    "                           \"train_decode_type\": \"sampling\",\n",
+    "                           \"val_decode_type\": \"greedy\",\n",
+    "                           \"test_decode_type\": \"beam_search\",\n",
+    "                       }\n",
+    "                       ) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdfa0c33-0f09-4316-84f9-25f6e8f8dfc0",
+   "metadata": {},
+   "source": [
+    "### Setup Trainer and train model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38e7840f-c3b7-4f47-b694-f00db7f25896",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer = RL4COTrainer(\n",
+    "    max_epochs=2,\n",
+    "    logger=None,\n",
+    ")\n",
+    "\n",
+    "trainer.fit(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7e92694-7a6c-4b86-b1f7-7fade55fdef5",
+   "metadata": {},
+   "source": [
+    "### Test the model using Trainer class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea794e13-5af6-41cc-b3cc-1a6b42520086",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# here we evaluate the model on the test set using the beam search decoding strategy as declared in the model constructor\n",
+    "trainer.test(model=model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36ec98df-17d3-4250-9a9f-c1d510175934",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can simply change the decoding type of the current model instance\n",
+    "model.policy.test_decode_type = \"greedy\"\n",
+    "trainer.test(model=model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08f2744e-83ea-402a-83ec-94cbf12a0870",
+   "metadata": {},
+   "source": [
+    "### Manual Test Loop\n",
+    "\n",
+    "Let's compare beam search with a greedy decoding strategy by manually looping over our test dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2b89503-f416-4b73-a5dc-1f1dfd7369e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bs_rewards = []\n",
+    "for batch in model.test_dataloader():\n",
+    "    td = env.reset(batch)\n",
+    "    with torch.no_grad():\n",
+    "        # in a manual loop we can dynamically specify the decode type\n",
+    "        out = model(td, decode_type=\"beam_search\", beam_width=10)\n",
+    "    bs_rewards.append(out[\"reward\"])\n",
+    "print(\"Average reward is %s\" % torch.cat(bs_rewards).mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2103e579-d35f-4496-b401-47e9d3be7caa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bs_rewards = []\n",
+    "for batch in model.test_dataloader():\n",
+    "    td = env.reset(batch)\n",
+    "    with torch.no_grad():\n",
+    "        out = model(td, decode_type=\"greedy\")\n",
+    "    bs_rewards.append(out[\"reward\"])\n",
+    "print(\"Average reward is %s\" % torch.cat(bs_rewards).mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41b902d8-446a-4d3e-b14e-673560ca7af1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bs_rewards = []\n",
+    "for batch in model.test_dataloader():\n",
+    "    td = env.reset(batch)\n",
+    "    bs = batch.batch_size[0]\n",
+    "    with torch.no_grad():\n",
+    "        out = model(td, decode_type=\"multistart_greedy\", num_starts=10, return_actions=True)\n",
+    "        rewards = torch.stack(out[\"reward\"].split(bs), 1).max(1).values\n",
+    "    bs_rewards.append(rewards)\n",
+    "print(\"Average reward is %s\" % torch.cat(bs_rewards).mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce439b05-9c60-42d0-b51b-07412b279e0a",
+   "metadata": {},
+   "source": [
+    "We can see that beam search finds a better solution than the greedy decoder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9e1793c-5bff-4a34-81f7-de080551ffad",
+   "metadata": {},
+   "source": [
+    "### Digging deeper into beam search solutions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cb7284a-6b3f-41fa-9589-d41dd7458721",
+   "metadata": {},
+   "source": [
+    "We can also analyze the different solutions obtained via beam search when passing \"select_best=False\" to the forward pass of the policy. The solutions in this case are sorted per instance-wise, that is:\n",
+    "\n",
+    "- instance1_solution1\n",
+    "- instance2_solution1\n",
+    "- instance3_solution1\n",
+    "- instance1_solution2\n",
+    "- instance2_solution2\n",
+    "- instance3_solution2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d476c7a-aa23-45bb-b3e9-441992dcdf81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "td = env.reset(batch)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9e59a46-8aea-4739-a16d-913e3d3b8d0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bs = batch.batch_size[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01727816-25ff-4a21-b092-b3a72be19343",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out = model(td, decode_type=\"beam_search\", beam_width=5, select_best=False, return_actions=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5366d787-2ac7-4d0c-bffc-926d64c82b63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we split the sequence ofter every \"batch_size\" instances, then stack the different solutions obtained for each minibatch instance by the beam search together.\n",
+    "actions_stacked = torch.stack(out[\"actions\"].split(bs), 1)\n",
+    "rewards_stacked = torch.stack(out[\"reward\"].split(bs), 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ee02330-965b-48f3-8cf8-ed20ed7e1af6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "batch_instance = 0\n",
+    "for i, actions in enumerate(actions_stacked[batch_instance].cpu()):\n",
+    "    reward = rewards_stacked[batch_instance, i]\n",
+    "    _, ax = plt.subplots()\n",
+    "    \n",
+    "    env.render(td[0], actions, ax=ax)\n",
+    "    ax.set_title(\"Reward: %s\" % reward.item())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rl4co/models/nn/dec_strategies.py
+++ b/rl4co/models/nn/dec_strategies.py
@@ -4,13 +4,10 @@ import torch.nn as nn
 from tensordict.tensordict import TensorDict
 import warnings
 from typing import Tuple
-from collections import defaultdict
-from dataclasses import dataclass, fields, replace
-
 
 from rl4co.envs import RL4COEnvBase
 from rl4co.utils.pylogger import get_pylogger
-from rl4co.utils.ops import batchify, get_num_starts, select_start_nodes, unbatchify
+from rl4co.utils.ops import batchify, get_num_starts, select_start_nodes
 
 
 log = get_pylogger(__name__)
@@ -50,27 +47,9 @@ class DecodingStrategy(nn.Module):
 
     def _step(self, logp: torch.Tensor, td: TensorDict, **kwargs) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError("Must be implemented by subclass")
-    
+        
 
-    def _pre_step_hook(self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs):
-        # probs = logp.exp()
-        # assert (probs == probs).all(), "Probs should not contain any nans"
-        assert not logp.isinf().all(1).any()  # This should do the same but without doing the .exp transform
-        # assert ~logp.isinf().all(1).all() 
-
-        return logp, td
-
-
-    def _post_step_hook(self, selected: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs):
-
-        assert not mask.gather(
-            1, selected.unsqueeze(-1)
-        ).data.any(), "infeasible action selected"
-
-        return selected, td
-    
-
-    def pre_hook(self, td: TensorDict, env: RL4COEnvBase, num_starts: int = None):
+    def pre_decoder_hook(self, td: TensorDict, env: RL4COEnvBase, num_starts: int = None):
 
         # Multi-start decoding. If num_starts is None, we use the number of actions in the action mask
         if self.multistart:
@@ -103,7 +82,8 @@ class DecodingStrategy(nn.Module):
 
         return td, env, self.num_starts
 
-    def post_hook(self, td, env):
+
+    def post_decoder_hook(self, td, env):
 
         assert (
             len(self.logp) > 0
@@ -118,9 +98,9 @@ class DecodingStrategy(nn.Module):
              td: TensorDict, 
              **kwargs) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
         
-        logp, td = self._pre_step_hook(logp, mask, td, **kwargs)        
-        selected_actions, td = self._step(logp, mask, td, **kwargs)
-        selected_actions, td = self._post_step_hook(selected_actions, mask, td, **kwargs) 
+        assert not logp.isinf().all(1).any()
+ 
+        logp, selected_actions, td = self._step(logp, mask, td, **kwargs)
 
         td.set("action", selected_actions)
 
@@ -148,7 +128,11 @@ class Greedy(DecodingStrategy):
         # [BS], [BS]
         _, selected = logp.max(1)
 
-        return selected, td
+        assert not mask.gather(
+            1, selected.unsqueeze(-1)
+        ).data.any(), "infeasible action selected"
+
+        return logp, selected, td
 
 
 class Sampling(DecodingStrategy):
@@ -171,46 +155,84 @@ class Sampling(DecodingStrategy):
         while mask.gather(1, selected.unsqueeze(-1)).data.any():
             log.info("Sampled bad values, resampling!")
             selected = probs.multinomial(1).squeeze(1)
+        
+        assert not mask.gather(
+            1, selected.unsqueeze(-1)
+        ).data.any(), "infeasible action selected"
 
-        return selected, td
+        return logp, selected, td
 
 
 class BeamSearch(DecodingStrategy):
 
     name = "beam_search"
 
-    def __init__(self, beam_width, select_best=True, *args, **kwargs) -> None:
+    def __init__(self, beam_width=None, select_best=True, *args, **kwargs) -> None:
         super().__init__()
         self.beam_width = beam_width
         self.select_best = select_best
-        self.step_num = 0
-        self.log_beam_probs = []
+        self.parent_beam_logp = None
         self.beam_path = []
-        if beam_width <= 1:
-            warnings.warn("Beam width is <= 1 in Beam search. This might not be what you want")
-
-    # def setup_state(self, state: StateMSVRP):
-    #     return state.repeat(self.beam_width)
 
     def _step(self, 
-              probs: torch.Tensor, 
+              logp: torch.Tensor, 
               mask: torch.Tensor, 
               td: TensorDict, 
               **kwargs) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
 
-        selected, batch_beam_idx = self._make_beam_step(probs)
-        # first select the correct state representation according to beam parent
+        selected, batch_beam_idx = self._make_beam_step(logp)
+        # select the correct state representation, logp and mask according to beam parent
         td = td[batch_beam_idx] 
+        logp = logp[batch_beam_idx]
+        mask = mask[batch_beam_idx]
 
-        self.step_num += 1
+        assert not mask.gather(
+            1, selected.unsqueeze(-1)
+        ).data.any(), "infeasible action selected"
 
-        return selected, td
+        return logp, selected, td
+    
+
+    def pre_decoder_hook(self, td: TensorDict, env: RL4COEnvBase, **kwargs):
+        if self.beam_width is None:
+            self.beam_width = get_num_starts(td, env.name)
+
+        # select start nodes. TODO: include first step in beam search as well
+        action = select_start_nodes(td, env, self.beam_width)
+
+        # Expand td to batch_size * beam_width
+        td = batchify(td, self.beam_width)
+
+        td.set("action", action)
+        td = env.step(td)["next"]
+
+        log_p = torch.zeros_like(
+            td["action_mask"], device=td.device
+        )
+
+        self.logp.append(log_p)
+        self.actions.append(action)
+        self.parent_beam_logp = log_p.gather(1, action[...,None])
+        self.beam_path.append(torch.zeros(log_p.size(0)))
+
+        return td, env, self.beam_width
+    
+    
+    def post_decoder_hook(self, td, env):
+        # [BS*BW, seq_len]
+        aligned_sequences, aligned_probs = self._backtrack()
+        
+        if self.select_best:
+            return self._select_best_beam(aligned_probs, aligned_sequences, td, env)
+        else:
+            return aligned_probs, aligned_sequences, td, env
+        
 
     def _backtrack(self):
 
-        # [BS*BW, seq_len*num_targets]
+        # [BS*BW, seq_len]
         actions = torch.stack(self.actions, 1)
-        # [BS*BW, seq_len*num_targets]
+        # [BS*BW, seq_len]
         logp = torch.stack(self.logp, 1)
         assert actions.size(1) == len(self.beam_path), "action idx shape and beam path shape dont match"
 
@@ -236,110 +258,35 @@ class BeamSearch(DecodingStrategy):
         actions = torch.stack(list(reversed(reversed_aligned_sequences)), dim=1)
         logp = torch.stack(list(reversed(reversed_aligned_logp)), dim=1)
 
-
         return actions, logp
     
 
-    def _select_best_beam(self, probs, actions, td: TensorDict, env: RL4COEnvBase):
+    def _select_best_beam(self, logp, actions, td: TensorDict, env: RL4COEnvBase):
 
-        aug_batch_size = probs.size(0)  # num nodes (with depot)
+        aug_batch_size = logp.size(0)  # num nodes
         batch_size = aug_batch_size // self.beam_width
-
-        costs = env.get_reward(td, actions)
-        _, idx = torch.cat(costs.unsqueeze(1).split(batch_size), 1).min(1)
-        flat_idx = torch.arange(batch_size, device=costs.device) + idx * batch_size
-        return probs[flat_idx], actions[flat_idx], td[flat_idx]
+        rewards = env.get_reward(td, actions)
+        _, idx = torch.cat(rewards.unsqueeze(1).split(batch_size), 1).max(1)
+        flat_idx = torch.arange(batch_size, device=rewards.device) + idx * batch_size
+        return logp[flat_idx], actions[flat_idx], td[flat_idx], env
     
 
-    def post_hook(self, td, env):
-        # [BS*BW, seq_len]
-        aligned_sequences, aligned_probs = self._backtrack()
+    def _make_beam_step(self, logp: torch.Tensor):
 
-        if self.select_best and not self.training:
-            return self._select_best_beam(aligned_probs, aligned_sequences, td, env)
-        else:
-            return aligned_probs, aligned_sequences, td, env
-        
-
-    def _fill_up_beams(self, topk_ind, topk_logp, log_beam_prob):
-        """There may be cases where there are less valid options than the specified beam width. This might not be a problem at 
-        the start of the beam search, since a few valid options can quickly grow to a lot more options  (if each valid option
-        splits up in two more options we have 2^x growth). However, there may also be cases in small instances where simply
-        too few options exist. We define these cases when every beam parent has only one valid child and the sum of valid child
-        nodes is less than the beam width. In these cases we fill the missing child nodes by duplicating the valid ones.
-        
-        Moreover, in early phases of the algorithm we may choose invalid nodes to fill the beam. We hardcode these options to
-        remain in the depot. These options get filtered out in later phases of the beam search since they have a logprob of -inf
-
-        params:
-        - topk_ind
-        - topk_logp
-        -log_beam_prob_hat [BS, num_nodes * beam_width]
-        """
-        if self.step_num > 0:
-
-            bs = topk_ind.size(0)
-            # [BS, num_nodes, beam_width]
-            avail_opt_per_beam = torch.stack(log_beam_prob.split(bs), -1).gt(-torch.inf).sum(1)
-
-            invalid = torch.logical_and(avail_opt_per_beam.le(1).all(1), avail_opt_per_beam.sum(1) < self.beam_width)
-            if invalid.any():
-                mask = topk_logp[invalid].isinf()
-                new_prob, new_ind = topk_logp[invalid].max(1)
-                new_prob_exp = new_prob[:,None].expand(-1, self.beam_width)
-                new_ind_exp = topk_ind[invalid, new_ind][:,None].expand(-1, self.beam_width)
-                topk_logp[invalid] = torch.where(mask, new_prob_exp, topk_logp[invalid])
-                topk_ind[invalid] = torch.where(mask, new_ind_exp, topk_ind[invalid])
-
-        # infeasible beam may remain in depot. Beam will be discarded anyway in next round
-        topk_ind[topk_logp.eq(-torch.inf)] = 0
-
-        return topk_ind, topk_logp
-
-
-    def _make_beam_step(self, probs: torch.Tensor):
-
-        aug_batch_size, num_nodes = probs.shape  # num nodes
+        aug_batch_size, num_nodes = logp.shape  # num nodes
         batch_size = aug_batch_size // self.beam_width
-        batch_beam_sequence = torch.arange(0, batch_size).repeat(self.beam_width).to(probs.device)
+        batch_beam_sequence = torch.arange(0, batch_size).repeat(self.beam_width).to(logp.device)
 
-        # do log transform in order to avoid that impossible actions are chosen in the beam
-        # [BS*BW, num_nodes]
-        logp = probs.clone().log()
+        # [BS*BW, num_nodes] + [BS*BW, 1] -> [BS*BW, num_nodes]
+        log_beam_prob = logp + self.parent_beam_logp# 
 
-        if self.step_num == 0:
-            # [BS, num_nodes]
-            log_beam_prob_hat = logp
-            log_beam_prob_hstacked = log_beam_prob_hat[:batch_size]
-
-            if num_nodes < self.beam_width:
-                # pack some artificial nodes onto logp
-                dummy = torch.full((batch_size, (self.beam_width-num_nodes)), -torch.inf, device=probs.device)
-                log_beam_prob_hstacked = torch.hstack((log_beam_prob_hstacked, dummy))
-
-            # [BS, BW]
-            topk_logp, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1, sorted=True)
-
-        else:
-            # determine the rank of every action per beam (descending order)
-            ranks = torch.argsort(torch.argsort(logp, dim=1, descending=True), dim=1)
-            # use the rank as penalty so as to promote the best option per beam
-            # [BS*BW, num_nodes] + [BS*BW, 1] -> [BS*BW, num_nodes]
-            log_beam_prob = logp + self.log_beam_probs[-1].unsqueeze(1) 
-
-            # [BS, num_nodes * BW]
-            log_beam_prob_hstacked = torch.cat(log_beam_prob.split(batch_size), dim=1)
-            # [BS, BW]
-            # _, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1)
-            # NOTE: for testing purposes
-            topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1, sorted=True)[1].sort(1)[0]
-            # we do not want to keep track of the penalty value, therefore discard it here
-            topk_logp = torch.cat(log_beam_prob.split(batch_size), dim=1).gather(1, topk_ind)
-
-        topk_ind, topk_logp = self._fill_up_beams(topk_ind, topk_logp, log_beam_prob)
+        # [BS, num_nodes * BW]
+        log_beam_prob_hstacked = torch.cat(log_beam_prob.split(batch_size), dim=1)
+        # [BS, BW]
+        topk_logp, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1)
 
         # [BS*BW, 1]
-        logp_selected = torch.hstack(torch.unbind(topk_logp,1))
+        logp_selected = torch.hstack(torch.unbind(topk_logp,1)).unsqueeze(1) 
 
         # [BS*BW, 1]
         topk_ind = torch.hstack(torch.unbind(topk_ind,1)) 
@@ -351,13 +298,9 @@ class BeamSearch(DecodingStrategy):
         # calc parent this branch comes from
         beam_parent = (topk_ind // num_nodes).int()
 
-        # extract the correct representations from "batch". Consider instances with 10 nodes and 
-        # a beam width of 3. If for the first problem instance the corresponding pointers are 1, 
-        # 5 and 15, we know that the first two branches come from the first root hypothesis, while 
-        # the latter comes from the second hypothesis. Consequently, the first two branches use the
-        # first representation of that instance while the latter uses its second representation
         batch_beam_idx = batch_beam_sequence + beam_parent * batch_size
 
+        self.parent_beam_logp = logp_selected
         self.beam_path.append(beam_parent)
 
         return selected, batch_beam_idx

--- a/rl4co/models/nn/dec_strategies.py
+++ b/rl4co/models/nn/dec_strategies.py
@@ -1,0 +1,363 @@
+import torch
+import torch.nn as nn
+
+from tensordict.tensordict import TensorDict
+import warnings
+from typing import Tuple
+from collections import defaultdict
+from dataclasses import dataclass, fields, replace
+
+
+from rl4co.envs import RL4COEnvBase
+from rl4co.utils.pylogger import get_pylogger
+from rl4co.utils.ops import batchify, get_num_starts, select_start_nodes, unbatchify
+
+
+log = get_pylogger(__name__)
+
+
+def get_decoding_strategy(decoding_strategy, **config):
+
+    strategy_registry = {
+        "greedy": Greedy,
+        "sampling": Sampling,
+        "multistart_greedy": Greedy,
+        "multistart_sampling": Sampling,
+        "beam_search": BeamSearch,
+    }
+
+    if decoding_strategy not in strategy_registry:
+        log.warning(
+            f"Unknown environment name '{decoding_strategy}'. Available dynamic embeddings: {strategy_registry.keys()}. Defaulting to Sampling."
+        )
+
+    if "multistart" in decoding_strategy:
+        config["multistart"] = True
+
+    return strategy_registry.get(decoding_strategy, Sampling)(**config)
+
+
+class DecodingStrategy(nn.Module):
+
+    name = ...
+
+    def __init__(self, *args, multistart=False, **kwargs) -> None:
+        super().__init__()
+        self.actions = []
+        self.logp = []
+        self.multistart = multistart
+
+
+    def _step(self, logp: torch.Tensor, td: TensorDict, **kwargs) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError("Must be implemented by subclass")
+    
+
+    def _pre_step_hook(self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs):
+        # probs = logp.exp()
+        # assert (probs == probs).all(), "Probs should not contain any nans"
+        assert not logp.isinf().all(1).any()  # This should do the same but without doing the .exp transform
+        # assert ~logp.isinf().all(1).all() 
+
+        return logp, td
+
+
+    def _post_step_hook(self, selected: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs):
+
+        assert not mask.gather(
+            1, selected.unsqueeze(-1)
+        ).data.any(), "infeasible action selected"
+
+        return selected, td
+    
+
+    def pre_hook(self, td: TensorDict, env: RL4COEnvBase, num_starts: int = None):
+
+        # Multi-start decoding. If num_starts is None, we use the number of actions in the action mask
+        if self.multistart:
+            if num_starts is None:
+                self.num_starts = get_num_starts(td, env.name)
+        else:
+            if num_starts is not None:
+                if num_starts > 1:
+                    log.warn(
+                        f"num_starts={num_starts} is ignored for decode_type={self.name}"
+                    )
+
+            self.num_starts = 0
+
+        # Multi-start decoding: first action is chosen by ad-hoc node selection
+        if self.num_starts > 1:
+            action = select_start_nodes(td, env, self.num_starts)
+
+            # Expand td to batch_size * num_starts
+            td = batchify(td, self.num_starts)
+
+            td.set("action", action)
+            td = env.step(td)["next"]
+            log_p = torch.zeros_like(
+                td["action_mask"], device=td.device
+            )  # first log_p is 0, so p = log_p.exp() = 1
+
+            self.logp.append(log_p)
+            self.actions.append(action)
+
+        return td, env, self.num_starts
+
+    def post_hook(self, td, env):
+
+        assert (
+            len(self.logp) > 0
+        ), "No outputs were collected because all environments were done. Check your initial state"
+
+        return torch.stack(self.logp, 1), torch.stack(self.actions, 1), td, env
+    
+    
+    def step(self, 
+             logp: torch.Tensor, 
+             mask: torch.Tensor,
+             td: TensorDict, 
+             **kwargs) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
+        
+        logp, td = self._pre_step_hook(logp, mask, td, **kwargs)        
+        selected_actions, td = self._step(logp, mask, td, **kwargs)
+        selected_actions, td = self._post_step_hook(selected_actions, mask, td, **kwargs) 
+
+        td.set("action", selected_actions)
+
+        self.actions.append(selected_actions)
+        self.logp.append(logp)
+
+        return td 
+
+
+class Greedy(DecodingStrategy):
+
+    name = "greedy"
+
+    def __init__(self, *args, multistart=False, **kwargs) -> None:
+        super().__init__()
+        self.multistart = multistart
+
+
+    def _step(self, 
+              logp: torch.Tensor, 
+              mask: torch.Tensor, 
+              td: TensorDict, 
+              **kwargs) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
+        
+        # [BS], [BS]
+        _, selected = logp.max(1)
+
+        return selected, td
+
+
+class Sampling(DecodingStrategy):
+
+    name = "sampling"
+
+    def __init__(self, *args, multistart=False, **kwargs) -> None:
+        super().__init__()
+        self.multistart = multistart
+
+    def _step(self, 
+              logp: torch.Tensor, 
+              mask: torch.Tensor,
+              td: TensorDict, 
+              **kwargs) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
+        
+        probs = logp.exp()
+        selected = torch.multinomial(probs, 1).squeeze(1)
+
+        while mask.gather(1, selected.unsqueeze(-1)).data.any():
+            log.info("Sampled bad values, resampling!")
+            selected = probs.multinomial(1).squeeze(1)
+
+        return selected, td
+
+
+class BeamSearch(DecodingStrategy):
+
+    name = "beam_search"
+
+    def __init__(self, beam_width, select_best=True, *args, **kwargs) -> None:
+        super().__init__()
+        self.beam_width = beam_width
+        self.select_best = select_best
+        self.step_num = 0
+        self.log_beam_probs = []
+        self.beam_path = []
+        if beam_width <= 1:
+            warnings.warn("Beam width is <= 1 in Beam search. This might not be what you want")
+
+    # def setup_state(self, state: StateMSVRP):
+    #     return state.repeat(self.beam_width)
+
+    def _step(self, 
+              probs: torch.Tensor, 
+              mask: torch.Tensor, 
+              td: TensorDict, 
+              **kwargs) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
+
+        selected, batch_beam_idx = self._make_beam_step(probs)
+        # first select the correct state representation according to beam parent
+        td = td[batch_beam_idx] 
+
+        self.step_num += 1
+
+        return selected, td
+
+    def _backtrack(self):
+
+        # [BS*BW, seq_len*num_targets]
+        actions = torch.stack(self.actions, 1)
+        # [BS*BW, seq_len*num_targets]
+        logp = torch.stack(self.logp, 1)
+        assert actions.size(1) == len(self.beam_path), "action idx shape and beam path shape dont match"
+
+        # [BS*BW]
+        cur_parent = self.beam_path[-1]
+        # [BS*BW]
+        reversed_aligned_sequences = [actions[:, -1]]
+        reversed_aligned_logp = [logp[:, -1]]
+
+        aug_batch_size = actions.size(0)
+        batch_size = aug_batch_size // self.beam_width
+        batch_beam_sequence = torch.arange(0, batch_size).repeat(self.beam_width).to(actions.device)
+
+        for k in reversed(range(len(self.beam_path)-1)):
+
+            batch_beam_idx = batch_beam_sequence + cur_parent * batch_size 
+
+            reversed_aligned_sequences.append(actions[batch_beam_idx, k])
+            reversed_aligned_logp.append(logp[batch_beam_idx, k])
+            cur_parent = self.beam_path[k][batch_beam_idx]
+
+        # [BS*BW, seq_len*num_targets]
+        actions = torch.stack(list(reversed(reversed_aligned_sequences)), dim=1)
+        logp = torch.stack(list(reversed(reversed_aligned_logp)), dim=1)
+
+
+        return actions, logp
+    
+
+    def _select_best_beam(self, probs, actions, td: TensorDict, env: RL4COEnvBase):
+
+        aug_batch_size = probs.size(0)  # num nodes (with depot)
+        batch_size = aug_batch_size // self.beam_width
+
+        costs = env.get_reward(td, actions)
+        _, idx = torch.cat(costs.unsqueeze(1).split(batch_size), 1).min(1)
+        flat_idx = torch.arange(batch_size, device=costs.device) + idx * batch_size
+        return probs[flat_idx], actions[flat_idx], td[flat_idx]
+    
+
+    def post_hook(self, td, env):
+        # [BS*BW, seq_len]
+        aligned_sequences, aligned_probs = self._backtrack()
+
+        if self.select_best and not self.training:
+            return self._select_best_beam(aligned_probs, aligned_sequences, td, env)
+        else:
+            return aligned_probs, aligned_sequences, td, env
+        
+
+    def _fill_up_beams(self, topk_ind, topk_logp, log_beam_prob):
+        """There may be cases where there are less valid options than the specified beam width. This might not be a problem at 
+        the start of the beam search, since a few valid options can quickly grow to a lot more options  (if each valid option
+        splits up in two more options we have 2^x growth). However, there may also be cases in small instances where simply
+        too few options exist. We define these cases when every beam parent has only one valid child and the sum of valid child
+        nodes is less than the beam width. In these cases we fill the missing child nodes by duplicating the valid ones.
+        
+        Moreover, in early phases of the algorithm we may choose invalid nodes to fill the beam. We hardcode these options to
+        remain in the depot. These options get filtered out in later phases of the beam search since they have a logprob of -inf
+
+        params:
+        - topk_ind
+        - topk_logp
+        -log_beam_prob_hat [BS, num_nodes * beam_width]
+        """
+        if self.step_num > 0:
+
+            bs = topk_ind.size(0)
+            # [BS, num_nodes, beam_width]
+            avail_opt_per_beam = torch.stack(log_beam_prob.split(bs), -1).gt(-torch.inf).sum(1)
+
+            invalid = torch.logical_and(avail_opt_per_beam.le(1).all(1), avail_opt_per_beam.sum(1) < self.beam_width)
+            if invalid.any():
+                mask = topk_logp[invalid].isinf()
+                new_prob, new_ind = topk_logp[invalid].max(1)
+                new_prob_exp = new_prob[:,None].expand(-1, self.beam_width)
+                new_ind_exp = topk_ind[invalid, new_ind][:,None].expand(-1, self.beam_width)
+                topk_logp[invalid] = torch.where(mask, new_prob_exp, topk_logp[invalid])
+                topk_ind[invalid] = torch.where(mask, new_ind_exp, topk_ind[invalid])
+
+        # infeasible beam may remain in depot. Beam will be discarded anyway in next round
+        topk_ind[topk_logp.eq(-torch.inf)] = 0
+
+        return topk_ind, topk_logp
+
+
+    def _make_beam_step(self, probs: torch.Tensor):
+
+        aug_batch_size, num_nodes = probs.shape  # num nodes
+        batch_size = aug_batch_size // self.beam_width
+        batch_beam_sequence = torch.arange(0, batch_size).repeat(self.beam_width).to(probs.device)
+
+        # do log transform in order to avoid that impossible actions are chosen in the beam
+        # [BS*BW, num_nodes]
+        logp = probs.clone().log()
+
+        if self.step_num == 0:
+            # [BS, num_nodes]
+            log_beam_prob_hat = logp
+            log_beam_prob_hstacked = log_beam_prob_hat[:batch_size]
+
+            if num_nodes < self.beam_width:
+                # pack some artificial nodes onto logp
+                dummy = torch.full((batch_size, (self.beam_width-num_nodes)), -torch.inf, device=probs.device)
+                log_beam_prob_hstacked = torch.hstack((log_beam_prob_hstacked, dummy))
+
+            # [BS, BW]
+            topk_logp, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1, sorted=True)
+
+        else:
+            # determine the rank of every action per beam (descending order)
+            ranks = torch.argsort(torch.argsort(logp, dim=1, descending=True), dim=1)
+            # use the rank as penalty so as to promote the best option per beam
+            # [BS*BW, num_nodes] + [BS*BW, 1] -> [BS*BW, num_nodes]
+            log_beam_prob = logp + self.log_beam_probs[-1].unsqueeze(1) 
+
+            # [BS, num_nodes * BW]
+            log_beam_prob_hstacked = torch.cat(log_beam_prob.split(batch_size), dim=1)
+            # [BS, BW]
+            # _, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1)
+            # NOTE: for testing purposes
+            topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1, sorted=True)[1].sort(1)[0]
+            # we do not want to keep track of the penalty value, therefore discard it here
+            topk_logp = torch.cat(log_beam_prob.split(batch_size), dim=1).gather(1, topk_ind)
+
+        topk_ind, topk_logp = self._fill_up_beams(topk_ind, topk_logp, log_beam_prob)
+
+        # [BS*BW, 1]
+        logp_selected = torch.hstack(torch.unbind(topk_logp,1))
+
+        # [BS*BW, 1]
+        topk_ind = torch.hstack(torch.unbind(topk_ind,1)) 
+
+        # since we stack the logprobs from the distinct branches, the indices in 
+        # topk dont correspond to node indices directly and need to be translated
+        selected = topk_ind % num_nodes  # determine node index
+
+        # calc parent this branch comes from
+        beam_parent = (topk_ind // num_nodes).int()
+
+        # extract the correct representations from "batch". Consider instances with 10 nodes and 
+        # a beam width of 3. If for the first problem instance the corresponding pointers are 1, 
+        # 5 and 15, we know that the first two branches come from the first root hypothesis, while 
+        # the latter comes from the second hypothesis. Consequently, the first two branches use the
+        # first representation of that instance while the latter uses its second representation
+        batch_beam_idx = batch_beam_sequence + beam_parent * batch_size
+
+        self.beam_path.append(beam_parent)
+
+        return selected, batch_beam_idx

--- a/rl4co/models/zoo/common/autoregressive/decoder.py
+++ b/rl4co/models/zoo/common/autoregressive/decoder.py
@@ -10,12 +10,12 @@ from torch import Tensor
 
 from rl4co.envs import RL4COEnvBase, get_env
 from rl4co.models.nn.attention import LogitAttention
+from rl4co.models.nn.dec_strategies import DecodingStrategy, get_decoding_strategy
 from rl4co.models.nn.env_embeddings import env_context_embedding, env_dynamic_embedding
 from rl4co.models.nn.env_embeddings.dynamic import StaticEmbedding
-from rl4co.models.nn.utils import decode_probs, get_log_likelihood
-from rl4co.utils.ops import batchify, get_num_starts, select_start_nodes, unbatchify
+from rl4co.models.nn.utils import get_log_likelihood
+from rl4co.utils.ops import batchify, select_start_nodes, unbatchify
 from rl4co.utils.pylogger import get_pylogger
-from rl4co.models.nn.dec_strategies import DecodingStrategy, get_decoding_strategy
 
 log = get_pylogger(__name__)
 
@@ -146,7 +146,6 @@ class AutoregressiveDecoder(nn.Module):
             actions: Tensor of shape (batch_size, seq_len) containing the sampled actions
             td: TensorDict containing the environment state after decoding
         """
-
         # Instantiate environment if needed
         if isinstance(env, str):
             env_name = self.env_name if env is None else env
@@ -157,7 +156,9 @@ class AutoregressiveDecoder(nn.Module):
 
         # setup decoding strategy
         self.decode_strategy: DecodingStrategy = get_decoding_strategy(decode_type)
-        td, env, num_starts = self.decode_strategy.pre_decoder_hook(td, env, num_starts=num_starts)
+        td, env, num_starts = self.decode_strategy.pre_decoder_hook(
+            td, env, num_starts=num_starts
+        )
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():

--- a/rl4co/models/zoo/common/autoregressive/decoder.py
+++ b/rl4co/models/zoo/common/autoregressive/decoder.py
@@ -157,7 +157,7 @@ class AutoregressiveDecoder(nn.Module):
 
         # setup decoding strategy
         self.decode_strategy: DecodingStrategy = get_decoding_strategy(decode_type)
-        td, env, num_starts = self.decode_strategy.pre_hook(td, env, num_starts=num_starts)
+        td, env, num_starts = self.decode_strategy.pre_decoder_hook(td, env, num_starts=num_starts)
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():
@@ -165,7 +165,7 @@ class AutoregressiveDecoder(nn.Module):
             td = self.decode_strategy.step(log_p, mask, td)
             td = env.step(td)["next"]
 
-        outputs, actions, td, env = self.decode_strategy.post_hook(td, env)
+        outputs, actions, td, env = self.decode_strategy.post_decoder_hook(td, env)
 
         if calc_reward:
             td.set("reward", env.get_reward(td, actions))

--- a/rl4co/models/zoo/common/autoregressive/decoder.py
+++ b/rl4co/models/zoo/common/autoregressive/decoder.py
@@ -15,6 +15,7 @@ from rl4co.models.nn.env_embeddings.dynamic import StaticEmbedding
 from rl4co.models.nn.utils import decode_probs, get_log_likelihood
 from rl4co.utils.ops import batchify, get_num_starts, select_start_nodes, unbatchify
 from rl4co.utils.pylogger import get_pylogger
+from rl4co.models.nn.dec_strategies import DecodingStrategy, get_decoding_strategy
 
 log = get_pylogger(__name__)
 
@@ -110,6 +111,8 @@ class AutoregressiveDecoder(nn.Module):
 
         self.select_start_nodes_fn = select_start_nodes_fn
 
+        self.decode_strategy = None
+
     def forward(
         self,
         td: TensorDict,
@@ -133,6 +136,7 @@ class AutoregressiveDecoder(nn.Module):
                 - "greedy": take the argmax of the logits
                 - "multistart_sampling": sample as sampling, but with multi-start decoding
                 - "multistart_greedy": sample as greedy, but with multi-start decoding
+                - "beam_search": perform beam search
             num_starts: Number of multi-starts to use. If None, will be calculated from the action mask
             softmax_temp: Temperature for the softmax. If None, default softmax is used from the `LogitAttention` module
             calc_reward: Whether to calculate the reward for the decoded sequence
@@ -148,59 +152,21 @@ class AutoregressiveDecoder(nn.Module):
             env_name = self.env_name if env is None else env
             env = get_env(env_name)
 
-        # Multi-start decoding. If num_starts is None, we use the number of actions in the action mask
-        if "multistart" in decode_type:
-            if num_starts is None:
-                num_starts = get_num_starts(td, env.name)
-        else:
-            if num_starts is not None:
-                if num_starts > 1:
-                    log.warn(
-                        f"num_starts={num_starts} is ignored for decode_type={decode_type}"
-                    )
-            num_starts = 0
-
         # Compute keys, values for the glimpse and keys for the logits once as they can be reused in every step
         cached_embeds = self._precompute_cache(embeddings, td=td)
 
-        # Collect outputs
-        outputs = []
-        actions = []
-
-        # Multi-start decoding: first action is chosen by ad-hoc node selection
-        if num_starts > 1 or "multistart" in decode_type:
-            action = self.select_start_nodes_fn(td, env, num_starts=num_starts)
-
-            # Expand td to batch_size * num_starts
-            td = batchify(td, num_starts)
-
-            td.set("action", action)
-            td = env.step(td)["next"]
-            log_p = torch.zeros_like(
-                td["action_mask"], device=td.device
-            )  # first log_p is 0, so p = log_p.exp() = 1
-
-            outputs.append(log_p)
-            actions.append(action)
+        # setup decoding strategy
+        self.decode_strategy: DecodingStrategy = get_decoding_strategy(decode_type)
+        td, env, num_starts = self.decode_strategy.pre_hook(td, env, num_starts=num_starts)
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():
             log_p, mask = self._get_log_p(cached_embeds, td, softmax_temp, num_starts)
-
-            # Select the indices of the next nodes in the sequences, result (batch_size) long
-            action = decode_probs(log_p.exp(), mask, decode_type=decode_type)
-
-            td.set("action", action)
+            td = self.decode_strategy.step(log_p, mask, td)
             td = env.step(td)["next"]
 
-            # Collect output of step
-            outputs.append(log_p)
-            actions.append(action)
+        outputs, actions, td, env = self.decode_strategy.post_hook(td, env)
 
-        assert (
-            len(outputs) > 0
-        ), "No outputs were collected because all environments were done. Check your initial state"
-        outputs, actions = torch.stack(outputs, 1), torch.stack(actions, 1)
         if calc_reward:
             td.set("reward", env.get_reward(td, actions))
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -31,6 +31,27 @@ def test_base_policy_multistart(env_name, size=20, batch_size=2):
     )  # to evaluate, we could just unbatchify
 
 
+@pytest.mark.parametrize(
+    "env_name",
+    ["tsp", "cvrp", "pctsp", "spctsp", "sdvrp", "op", "pdp"],
+)
+@pytest.mark.parametrize("select_best", [True, False])
+def test_base_policy_beam_search(env_name, select_best, size=20, batch_size=2):
+    env, x = generate_env_data(env_name, size, batch_size)
+    td = env.reset(x)
+    policy = AutoregressivePolicy(env.name)
+    beam_width = size // 2 if env.name in ["pdp"] else size
+    out = policy(
+        td, env, decode_type="beam_search", beam_width=beam_width, select_best=select_best
+    )
+
+    if select_best:
+        expected_shape = (batch_size,)
+    else:
+        expected_shape = (batch_size * beam_width,)
+    assert out["reward"].shape == expected_shape
+
+
 def test_pointer_network(size=20, batch_size=2):
     env, x = generate_env_data("tsp", size, batch_size)
     td = env.reset(x)


### PR DESCRIPTION
## Description

- added base DecodingStrategy class which defines the following functions
     1. __pre_decoder_hook__: called before the while loop in the autoregressive decoder
     2. __step__: is called in every iteration of the while loop and samples an action given the log probabilities. The actual logic is specified by the subclasses through a *_step* function
     3. __post_decoder_hook__: called right after the while loop, mainly used to concatenate outputs

- implemented the greedy and sampling decoding strategies using the DecodingStrategy baseclass. They also support multistart by simply specifying "multistart_greedy" as decode_type for example. From a user perspective, nothing changes here.

- added beam search using the DecodingStrategy baseclass overwriting the following functions:
     1. __pre_decoder_hook__: similar to the multistart options, the beam width (if not specified) is determined and the actions of the first iteration are simply the first *beam_width* nodes (this could be improved in the future)
     2. **_step**: performs the actual beam search
     3. __post_decoder_hook__: performs back tracking and brings the solution in the right format

- added new test function to check that the new approach doesn't break anything

## Motivation and Context

close #109 

- [x] I have raised an issue to propose this change

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.