### PR TITLE
[Notebooks] small markdown fix in decode strategies

### DIFF
--- a/notebooks/tutorials/7-decoding-strategies.ipynb
+++ b/notebooks/tutorials/7-decoding-strategies.ipynb
@@ -391,6 +391,38 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
+   "id": "2103e579-d35f-4496-b401-47e9d3be7caa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average reward is tensor(-4.2222)\n"
+     ]
+    }
+   ],
+   "source": [
+    "bs_rewards = []\n",
+    "for batch in model.test_dataloader():\n",
+    "    td = env.reset(batch)\n",
+    "    with torch.no_grad():\n",
+    "        out = model(td, decode_type=\"greedy\")\n",
+    "    bs_rewards.append(out[\"reward\"])\n",
+    "print(\"Average reward is %s\" % torch.cat(bs_rewards).mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5bab7f4",
+   "metadata": {},
+   "source": [
+    "### Beam search decoding\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 13,
    "id": "f2b89503-f416-4b73-a5dc-1f1dfd7369e3",
    "metadata": {},
@@ -410,38 +442,6 @@
     "    with torch.no_grad():\n",
     "        # in a manual loop we can dynamically specify the decode type\n",
     "        out = model(td, decode_type=\"beam_search\", beam_width=20)\n",
-    "    bs_rewards.append(out[\"reward\"])\n",
-    "print(\"Average reward is %s\" % torch.cat(bs_rewards).mean())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a5bab7f4",
-   "metadata": {},
-   "source": [
-    "### Beam search decoding\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "2103e579-d35f-4496-b401-47e9d3be7caa",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average reward is tensor(-4.2222)\n"
-     ]
-    }
-   ],
-   "source": [
-    "bs_rewards = []\n",
-    "for batch in model.test_dataloader():\n",
-    "    td = env.reset(batch)\n",
-    "    with torch.no_grad():\n",
-    "        out = model(td, decode_type=\"greedy\")\n",
     "    bs_rewards.append(out[\"reward\"])\n",
     "print(\"Average reward is %s\" % torch.cat(bs_rewards).mean())"
    ]


### PR DESCRIPTION
## Description

Small fix in the markdown of the decoding strategies tutorial notebook

## Motivation and Context

Greedy and beam search subsections were inverted