### PR TITLE
[BugFix] Batch size for data generation

### DIFF
--- a/rl4co/models/rl/common/base.py
+++ b/rl4co/models/rl/common/base.py
@@ -142,11 +142,11 @@ class RL4COLitModule(LightningModule):
 
         log.info("Setting up datasets")
         self.train_dataset = self.wrap_dataset(
-            self.env.dataset(self.data_cfg["train_data_size"], phase="train")
+            self.env.dataset(self.data_cfg["batch_size"], phase="train")
         )
-        self.val_dataset = self.env.dataset(self.data_cfg["val_data_size"], phase="val")
+        self.val_dataset = self.env.dataset(self.data_cfg["val_batch_size"], phase="val")
         self.test_dataset = self.env.dataset(
-            self.data_cfg["test_data_size"], phase="test"
+            self.data_cfg["test_batch_size"], phase="test"
         )
         self.dataloader_names = None
         self.setup_loggers()


### PR DESCRIPTION
# Description

This PR addresses an issue that appears when generating the data for an environment. The problem was that the whole dataset size was used for training, validation, and testing, instead of the specified batch sizes. 

# Motivation

Using total dataset sizes led memory allocation problems during environment setup. By switching to batch sizes, we assure that the data we handle has the right size.

# Types of Changes

- [x] Fix: Change data generation to use batch sizes.

# Checklist

- [x]  No new linting errors introduced.
- [x] Verified all changes are compatible with existing codebase.