### PR TITLE
[BugFix] fix bugs in warmup baseline

### DIFF
--- a/rl4co/models/rl/reinforce/baselines.py
+++ b/rl4co/models/rl/reinforce/baselines.py
@@ -118,15 +118,16 @@ class WarmupBaseline(REINFORCEBaseline):
         v_b, l_b = self.baseline.eval(td, reward, env)
         v_wb, l_wb = self.warmup_baseline.eval(td, reward, env)
         # Return convex combination of baseline and of loss
-        return self.alpha * v_b + (1 - self.alpha) * v_wb, self.alpha * l_b + (
-            1 - self.alpha * l_wb
+        return (
+            self.alpha * v_b + (1 - self.alpha) * v_wb,
+            self.alpha * l_b + (1 - self.alpha) * l_wb,
         )
 
     def epoch_callback(self, *args, **kw):
         # Need to call epoch callback of inner model (also after first epoch if we have not used it)
         self.baseline.epoch_callback(*args, **kw)
-        self.alpha = (kw["epoch"] + 1) / float(self.n_epochs)
         if kw["epoch"] < self.n_epochs:
+            self.alpha = (kw["epoch"] + 1) / float(self.n_epochs)
             log.info("Set warmup alpha = {}".format(self.alpha))
 
 
@@ -293,9 +294,9 @@ def get_reinforce_baseline(name, **kw):
         return WarmupBaseline(
             RolloutBaseline(bl_alpha=bl_alpha), warmup_epochs, warmup_exp_beta
         )
-    
+
     if name is None:
-        name = "no" # default to no baseline
+        name = "no"  # default to no baseline
     baseline_cls = REINFORCE_BASELINES_REGISTRY.get(name, None)
     if baseline_cls is None:
         raise ValueError(


### PR DESCRIPTION
## Description

fixes #133

There are bugs in the warmup baseline, which

1.) lead to self.alpha values larger than 1 as soon as the epoch is larger than the number of warmup epochs. Instead, once the number of warmup epochs is exceeded, it should only return the value of the actual baseline. With this PR, self.alpha is only updated as long as the warmup epochs are not exceeded yet. 

2.) lead to wrong combination of baseline losses due to a misplaced parentheses
 
See also this PR: https://github.com/wouterkool/attention-learn-to-route/pull/56

## Motivation and Context

Fixes the bugs mentioned above

- [x] I have raised an issue to propose this change ([required](https://github.com/ai4co/rl4co/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.