### PR TITLE
[Feat, Debug] Refactor augmentation class for flexible augment function and feature #139

### DIFF
--- a/notebooks/tutorials/5-test-on-tsplib.ipynb
+++ b/notebooks/tutorials/5-test-on-tsplib.ipynb
@@ -415,7 +415,7 @@
     "from rl4co.utils.ops import batchify, unbatchify\n",
     "\n",
     "num_augment = 100\n",
-    "augmentation = SymmetricStateAugmentation(env.name, num_augment=num_augment)\n",
+    "augmentation = SymmetricStateAugmentation(num_augment=num_augment)\n",
     "\n",
     "for problem_idx in range(len(problem_files)):\n",
     "    problem = load_problem(os.path.join(tsplib_dir, problem_files[problem_idx]))\n",

--- a/notebooks/tutorials/6-test-on-cvrplib.ipynb
+++ b/notebooks/tutorials/6-test-on-cvrplib.ipynb
@@ -359,7 +359,7 @@
     "from rl4co.utils.ops import batchify, unbatchify\n",
     "\n",
     "num_augment = 100\n",
-    "augmentation = SymmetricStateAugmentation(env.name, num_augment=num_augment)\n",
+    "augmentation = SymmetricStateAugmentation(num_augment=num_augment)\n",
     "\n",
     "for instance in instances:\n",
     "    problem = vrplib.read_instance(os.path.join(path_to_save, instance+'.vrp'))\n",

--- a/rl4co/data/transforms.py
+++ b/rl4co/data/transforms.py
@@ -108,6 +108,7 @@ class StateAugmentation(object):
         num_augment: number of augmentations
         augment_fn: augmentation function to use, e.g. 'symmetric' (default) or 'dihedral8', if callable, 
             then use the function directly. If 'dihedral8', then num_augment must be 8
+        first_aug_identity: whether to augment the first data point
         normalize: whether to normalize the augmented data
         feats: list of features to augment
     """
@@ -135,11 +136,12 @@ class StateAugmentation(object):
     def __call__(self, td: TensorDict) -> TensorDict:
         td_aug = batchify(td, self.num_augment)
         for feat in self.feats:
-            init_aug_feat = td_aug[feat][list(td.size()), 0].clone()
+            if not self.first_aug_identity:
+                init_aug_feat = td_aug[feat][list(td.size()), 0].clone()
             aug_feat = self.augmentation(td_aug[feat], self.num_augment)
             if self.normalize:
                 aug_feat = min_max_normalize(aug_feat)
-            if self.first_aug_identity:
+            if not self.first_aug_identity:
                 aug_feat[list(td.size()), 0] = init_aug_feat
             td_aug[feat] = aug_feat
 

--- a/rl4co/data/transforms.py
+++ b/rl4co/data/transforms.py
@@ -135,12 +135,12 @@ class StateAugmentation(object):
     def __call__(self, td: TensorDict) -> TensorDict:
         td_aug = batchify(td, self.num_augment)
         for feat in self.feats:
-            init_aug_feat = td_aug[feat][*td.size(), 0].clone()
+            init_aug_feat = td_aug[feat][list(td.size()), 0].clone()
             aug_feat = self.augmentation(td_aug[feat], self.num_augment)
             if self.normalize:
                 aug_feat = min_max_normalize(aug_feat)
             if self.first_aug_identity:
-                aug_feat[*td.size(), 0] = init_aug_feat
+                aug_feat[list(td.size()), 0] = init_aug_feat
             td_aug[feat] = aug_feat
 
         return td_aug

--- a/rl4co/data/transforms.py
+++ b/rl4co/data/transforms.py
@@ -98,7 +98,7 @@ def get_augment_function(augment_fn: Union[str, callable]):
         return dihedral_8_augmentation_wrapper
     if augment_fn == "symmetric":
         return symmetric_augmentation
-    raise ValueError(f"Unknown augment_fn: {augment_fn}")
+    raise ValueError(f"Unknown augment_fn: {augment_fn}. Available options: 'symmetric', 'dihedral8' or a custom callable")
 
 
 class StateAugmentation(object):
@@ -108,7 +108,7 @@ class StateAugmentation(object):
         num_augment: number of augmentations
         augment_fn: augmentation function to use, e.g. 'symmetric' (default) or 'dihedral8', if callable, 
             then use the function directly. If 'dihedral8', then num_augment must be 8
-        first_aug_identity: whether to augment the first data point
+        first_aug_identity: whether to augment the first data point too
         normalize: whether to normalize the augmented data
         feats: list of features to augment
     """
@@ -124,11 +124,13 @@ class StateAugmentation(object):
         self.augmentation = get_augment_function(augment_fn)
         assert not (
             self.augmentation == dihedral_8_augmentation_wrapper and num_augment != 8
-        ), "If using the `dihedral8` augmentation function, then num_augment must be 8"
+        ), "When using the `dihedral8` augmentation function, then num_augment must be 8"
 
         if feats is None:
-            log.info("Default augment feature: `locs`")
-        self.feats = ["locs"] if feats is None else feats
+            log.info("Features not passed, defaulting to 'locs'")
+            self.feats = ["locs"]
+        else:
+            self.feats = feats
         self.num_augment = num_augment
         self.normalize = normalize
         self.first_aug_identity = first_aug_identity

--- a/rl4co/data/transforms.py
+++ b/rl4co/data/transforms.py
@@ -105,9 +105,9 @@ class StateAugmentation(object):
     """Augment state by N times via symmetric rotation/reflection transform
 
     Args:
-        env_name: environment name
         num_augment: number of augmentations
-        use_dihedral_8: whether to use dihedral_8_augmentation.  If True, then num_augment must be 8
+        augment_fn: augmentation function to use, e.g. 'symmetric' (default) or 'dihedral8', if callable, 
+            then use the function directly. If 'dihedral8', then num_augment must be 8
         normalize: whether to normalize the augmented data
         feats: list of features to augment
     """

--- a/rl4co/models/zoo/active_search/search.py
+++ b/rl4co/models/zoo/active_search/search.py
@@ -81,9 +81,8 @@ class ActiveSearch(SearchBase):
 
         # Instantiate augmentation
         self.augmentation = StateAugmentation(
-            self.env.name,
             num_augment=self.hparams.augment_size,
-            use_dihedral_8=self.hparams.augment_dihedral,
+            augment_fn='dihedral8' if self.hparams.augment_dihedral else 'symmetric',
         )
 
         # Store original policy state dict

--- a/rl4co/models/zoo/eas/search.py
+++ b/rl4co/models/zoo/eas/search.py
@@ -109,9 +109,8 @@ class EAS(SearchBase):
 
         # Instantiate augmentation
         self.augmentation = StateAugmentation(
-            self.env.name,
             num_augment=self.hparams.augment_size,
-            use_dihedral_8=self.hparams.augment_dihedral,
+            augment_fn='dihedral8' if self.hparams.augment_dihedral else 'symmetric',
         )
 
         # Store original policy state dict

--- a/rl4co/models/zoo/matnet/model.py
+++ b/rl4co/models/zoo/matnet/model.py
@@ -22,13 +22,14 @@ class MatNet(POMO):
         if policy is None:
             policy = MatNetPolicy(env_name=env.name, **policy_params)
 
-        # Check if num_augment is not 0 or if diheral_8 is True
+        # Check if using augmentation and the validation of augmentation function
         if kwargs.get("num_augment", 0) != 0:
-            log.error("MatNet does not use symmetric augmentation. Setting num_augment to 0.")
-        kwargs["num_augment"] = 0
-        if kwargs.get("augment_fn") != 'symmetric':
-            log.error("MatNet does not use symmetric Dihedral Augmentation. Setting use_dihedral_8 to False.")
-        kwargs["augment_fn"] = 'symmetric'
+            log.warning("MatNet is using augmentation.")
+            if kwargs.get("augment_fn") in ['symmetric', 'dihedral8'] or kwargs.get("augment_fn") is None:
+                log.error("MatNet does not use symmetric or dihedral augmentation. Seeting no augmentation function.")
+                kwargs["num_augment"] = 0
+        else:
+            kwargs["num_augment"] = 0
 
         super(MatNet, self).__init__(
             env=env,

--- a/rl4co/models/zoo/matnet/model.py
+++ b/rl4co/models/zoo/matnet/model.py
@@ -26,9 +26,9 @@ class MatNet(POMO):
         if kwargs.get("num_augment", 0) != 0:
             log.error("MatNet does not use symmetric augmentation. Setting num_augment to 0.")
         kwargs["num_augment"] = 0
-        if kwargs.get("use_dihedral_8", True):
+        if kwargs.get("augment_fn") != 'symmetric':
             log.error("MatNet does not use symmetric Dihedral Augmentation. Setting use_dihedral_8 to False.")
-        kwargs["use_dihedral_8"] = False
+        kwargs["augment_fn"] = 'symmetric'
 
         super(MatNet, self).__init__(
             env=env,

--- a/rl4co/models/zoo/pomo/model.py
+++ b/rl4co/models/zoo/pomo/model.py
@@ -28,7 +28,8 @@ class POMO(REINFORCE):
         baseline: Baseline to use for the algorithm. Note that POMO only supports shared baseline,
             so we will throw an error if anything else is passed.
         num_augment: Number of augmentations (used only for validation and test)
-        augment_fn: Function to use for augmentation, defaulting to dihedral_8_augmentation
+        augment_fn: Function to use for augmentation, defaulting to dihedral8
+        first_aug_identity: Whether to include the identity augmentation in the first position
         feats: List of features to augment
         num_starts: Number of starts for multi-start. If None, use the number of available actions
         select_start_nodes_fn: Function to select the start nodes for the environment defaulting to :func:`select_start_nodes`
@@ -43,6 +44,7 @@ class POMO(REINFORCE):
         baseline: str = "shared",
         num_augment: int = 8,
         augment_fn: Union[str, callable] = "dihedral8",
+        first_aug_identity: bool = True,
         feats: list = None,
         num_starts: int = None,
         select_start_nodes_fn: callable = select_start_nodes,
@@ -69,7 +71,7 @@ class POMO(REINFORCE):
         self.num_augment = num_augment
         if self.num_augment > 1:
             self.augment = StateAugmentation(
-                num_augment=self.num_augment, augment_fn=augment_fn, feats=feats
+                num_augment=self.num_augment, augment_fn=augment_fn, first_aug_identity=first_aug_identity, feats=feats
             )
         else:
             self.augment = None

--- a/rl4co/models/zoo/pomo/model.py
+++ b/rl4co/models/zoo/pomo/model.py
@@ -41,7 +41,8 @@ class POMO(REINFORCE):
         policy_kwargs={},
         baseline: str = "shared",
         num_augment: int = 8,
-        use_dihedral_8: bool = True,
+        augment_fn: Union[str, callable] = "dihedral8",
+        feats: list[str] = None,
         num_starts: int = None,
         select_start_nodes_fn: callable = select_start_nodes,
         **kwargs,
@@ -67,7 +68,7 @@ class POMO(REINFORCE):
         self.num_augment = num_augment
         if self.num_augment > 1:
             self.augment = StateAugmentation(
-                self.env.name, num_augment=self.num_augment, use_dihedral_8=use_dihedral_8
+                num_augment=self.num_augment, augment_fn=augment_fn, feats=feats
             )
         else:
             self.augment = None

--- a/rl4co/models/zoo/pomo/model.py
+++ b/rl4co/models/zoo/pomo/model.py
@@ -43,7 +43,7 @@ class POMO(REINFORCE):
         baseline: str = "shared",
         num_augment: int = 8,
         augment_fn: Union[str, callable] = "dihedral8",
-        feats: list[str] = None,
+        feats: list = None,
         num_starts: int = None,
         select_start_nodes_fn: callable = select_start_nodes,
         **kwargs,

--- a/rl4co/models/zoo/pomo/model.py
+++ b/rl4co/models/zoo/pomo/model.py
@@ -28,7 +28,8 @@ class POMO(REINFORCE):
         baseline: Baseline to use for the algorithm. Note that POMO only supports shared baseline,
             so we will throw an error if anything else is passed.
         num_augment: Number of augmentations (used only for validation and test)
-        use_dihedral_8: Whether to use dihedral 8 augmentation
+        augment_fn: Function to use for augmentation, defaulting to dihedral_8_augmentation
+        feats: List of features to augment
         num_starts: Number of starts for multi-start. If None, use the number of available actions
         select_start_nodes_fn: Function to select the start nodes for the environment defaulting to :func:`select_start_nodes`
         **kwargs: Keyword arguments passed to the superclass

--- a/rl4co/models/zoo/symnco/model.py
+++ b/rl4co/models/zoo/symnco/model.py
@@ -42,7 +42,7 @@ class SymNCO(REINFORCE):
         baseline: str = "symnco",
         num_augment: int = 4,
         augment_fn: Union[str, callable] = "symmetric",
-        feats: list[str] = None,
+        feats: list = None,
         alpha: float = 0.2,
         beta: float = 1,
         num_starts: int = 0,

--- a/rl4co/models/zoo/symnco/model.py
+++ b/rl4co/models/zoo/symnco/model.py
@@ -39,6 +39,8 @@ class SymNCO(REINFORCE):
         policy_kwargs: dict = {},
         baseline: str = "symnco",
         num_augment: int = 4,
+        augment_fn: Union[str, callable] = "symmetric",
+        feats: list[str] = None,
         alpha: float = 0.2,
         beta: float = 1,
         num_starts: int = 0,
@@ -57,7 +59,7 @@ class SymNCO(REINFORCE):
 
         self.num_starts = num_starts
         self.num_augment = num_augment
-        self.augment = StateAugmentation(self.env.name, num_augment=self.num_augment)
+        self.augment = StateAugmentation(num_augment=self.num_augment, augment_fn=augment_fn, feats=feats)
         self.alpha = alpha  # weight for invariance loss
         self.beta = beta  # weight for solution symmetricity loss
 

--- a/rl4co/models/zoo/symnco/model.py
+++ b/rl4co/models/zoo/symnco/model.py
@@ -26,6 +26,8 @@ class SymNCO(REINFORCE):
         policy: Policy to use for the algorithm
         policy_kwargs: Keyword arguments for policy
         num_augment: Number of augmentations
+        augment_fn: Function to use for augmentation, defaulting to dihedral_8_augmentation
+        feats: List of features to augment
         alpha: weight for invariance loss
         beta: weight for solution symmetricity loss
         num_starts: Number of starts for multi-start. If None, use the number of available actions

--- a/rl4co/tasks/eval.py
+++ b/rl4co/tasks/eval.py
@@ -124,7 +124,7 @@ class AugmentationEval(EvalBase):
         check_unused_kwargs(self, kwargs)
         super().__init__(env, kwargs.get("progress", True))
         self.augmentation = StateAugmentation(
-            env.name, num_augment=num_augment, use_dihedral_8=force_dihedral_8
+            num_augment=num_augment, augment_fn='dihedral8' if force_dihedral_8 else 'symmetric'
         )
 
     def _inner(self, policy, td, num_augment=None):
@@ -250,7 +250,7 @@ class GreedyMultiStartAugmentEval(EvalBase):
             num_augment != 8 and force_dihedral_8
         ), "Cannot force dihedral 8 when num_augment != 8"
         self.augmentation = StateAugmentation(
-            env.name, num_augment=num_augment, use_dihedral_8=force_dihedral_8
+            num_augment=num_augment, augment_fn='dihedral8' if force_dihedral_8 else 'symmetric'
         )
 
     def _inner(self, policy, td, num_augment=None):

--- a/rl4co/tasks/eval.py
+++ b/rl4co/tasks/eval.py
@@ -120,11 +120,11 @@ class AugmentationEval(EvalBase):
 
     name = "augmentation"
 
-    def __init__(self, env, num_augment=8, force_dihedral_8=False, **kwargs):
+    def __init__(self, env, num_augment=8, force_dihedral_8=False, feats=None, **kwargs):
         check_unused_kwargs(self, kwargs)
         super().__init__(env, kwargs.get("progress", True))
         self.augmentation = StateAugmentation(
-            num_augment=num_augment, augment_fn='dihedral8' if force_dihedral_8 else 'symmetric'
+            num_augment=num_augment, augment_fn='dihedral8' if force_dihedral_8 else 'symmetric', feats=feats
         )
 
     def _inner(self, policy, td, num_augment=None):
@@ -239,7 +239,7 @@ class GreedyMultiStartAugmentEval(EvalBase):
     name = "multistart_greedy_augment"
 
     def __init__(
-        self, env, num_starts=None, num_augment=8, force_dihedral_8=False, **kwargs
+        self, env, num_starts=None, num_augment=8, force_dihedral_8=False, feats=None, **kwargs
     ):
         check_unused_kwargs(self, kwargs)
         super().__init__(env, kwargs.get("progress", True))
@@ -250,7 +250,7 @@ class GreedyMultiStartAugmentEval(EvalBase):
             num_augment != 8 and force_dihedral_8
         ), "Cannot force dihedral 8 when num_augment != 8"
         self.augmentation = StateAugmentation(
-            num_augment=num_augment, augment_fn='dihedral8' if force_dihedral_8 else 'symmetric'
+            num_augment=num_augment, augment_fn='dihedral8' if force_dihedral_8 else 'symmetric', feats=feats
         )
 
     def _inner(self, policy, td, num_augment=None):


### PR DESCRIPTION
## Description

This PR contains the refactoring of the `StateAugmentation()` class for a more flexible, modularized way to choose different augmentation functions and augmentation features.  

## Motivation and Context

As issue #139 raised by @aziabatz, using the `StateAugmentation()` to augment customized features is not intuitive. The default augmentation feature is `locs` for all environments, which may cause some bugs when working on customized environments without the `locs` feature. 

Besides, to make it more flexible and modularized for augment function selection, we replace the previous `use_dihedral_8: bool=False` with `augment_fn: Union[str, callable] = 'symmetric'` which allows users to use their own augmentation functions aside from given [symmetric augmentation function](https://github.com/ai4co/rl4co/blob/f97ca86ff0fa26726773cd32de5c21e6042f91d2/rl4co/data/transforms.py#L46) and [dihedral8 augmentation function](https://github.com/ai4co/rl4co/blob/f97ca86ff0fa26726773cd32de5c21e6042f91d2/rl4co/data/transforms.py#L11). 

- [x] I have raised an issue to propose this change ([required](https://github.com/ai4co/rl4co/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue): fix issue #139.
- [x] Breaking change (fix or feature that would cause existing functionality to change): ⚠️ this PR changes the function related to some classes call it, including POMO model, SymNCO model, and two active searching methods. We should be very careful to merge this branch.
- [x] Documentation (update in the documentation): I updated the comment of related functions.
- [x] Example (update in the folder of examples): I updated the calling of `StateAugmentation()` in tutorial notebooks.

## Checklist

- [x] My change requires a change to the documentation: some function comments will be changed.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.