### PR TITLE
Update attention.py

### DIFF
--- a/rl4co/models/zoo/ham/attention.py
+++ b/rl4co/models/zoo/ham/attention.py
@@ -56,7 +56,8 @@ class HeterogenousMHA(nn.Module):
             q: queries (batch_size, n_query, input_dim)
             h: data (batch_size, graph_size, input_dim)
             mask: mask (batch_size, n_query, graph_size) or viewable as that (i.e. can be 2 dim if n_query == 1)
-            Mask should contain 1 if attention is not possible (i.e. mask is negative adjacency)
+            
+        Mask should contain 1 if attention is not possible (i.e. mask is negative adjacency)
         """
         if h is None:
             h = q  # compute self-attention


### PR DESCRIPTION
A small linebreak typo that makes the doc look strange 

See https://rl4co.readthedocs.io/en/latest/_content/api/models/zoo.html#rl4co.models.zoo.ham.attention.HeterogenousMHA:~:text=possible%20(Mask%20_sphinx_paramlinks_rl4co.models.zoo.ham.attention.HeterogenousMHA.forward.should%20contain%201%20if%20attention%20is%20not)%20%E2%80%93

## Description

Added a line break.