### PR TITLE
[Feat] Decoding refactoring

### DIFF
--- a/configs/experiment/routing/am-xl.yaml
+++ b/configs/experiment/routing/am-xl.yaml
@@ -14,7 +14,7 @@ logger:
   wandb:
     project: "rl4co"
     tags: ["am", "${env.name}"]
-    group: ${env.name}${env.num_loc}"
+    group: "${env.name}${env.num_loc}"
     name: "am-xl-${env.name}${env.num_loc}"
 
 model:

--- a/configs/experiment/routing/pomo.yaml
+++ b/configs/experiment/routing/pomo.yaml
@@ -14,7 +14,7 @@ logger:
   wandb:
     project: "rl4co"
     tags: ["pomo", "${env.name}"]
-    group: ${env.name}${env.num_loc}"
+    group: "${env.name}${env.num_loc}"
     name: "pomo-${env.name}${env.num_loc}"
 
 model:

--- a/configs/experiment/routing/symnco.yaml
+++ b/configs/experiment/routing/symnco.yaml
@@ -14,7 +14,7 @@ logger:
   wandb:
     project: "rl4co"
     tags: ["symnco", "${env.name}"]
-    group: ${env.name}${env.num_loc}"
+    group: "${env.name}${env.num_loc}"
     name: "symnco-${env.name}${env.num_loc}"
 
 model:

--- a/rl4co/__init__.py
+++ b/rl4co/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0dev0"
+__version__ = "0.4.0dev1"

--- a/rl4co/models/nn/dec_strategies.py
+++ b/rl4co/models/nn/dec_strategies.py
@@ -31,11 +31,68 @@ def get_decoding_strategy(decoding_strategy, **config):
     return strategy_registry.get(decoding_strategy, Sampling)(**config)
 
 
+def modify_logits_for_top_p_filtering(logits, top_p):
+    """Set the logits for none top-p values to -inf. Done out-of-place.
+    Ref: https://github.com/togethercomputer/stripedhyena/blob/7e13f618027fea9625be1f2d2d94f9a361f6bd02/stripedhyena/sample.py#L14
+    """
+    if top_p <= 0.0 or top_p >= 1.0:
+        return logits
+
+    # First sort and calculate cumulative sum of probabilities.
+    sorted_logits, sorted_indices = torch.sort(logits, descending=False)
+    cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+    # Remove tokens with cumulative top_p above the threshold (token with 0 are kept)
+    sorted_indices_to_remove = cumulative_probs <= (1 - top_p)
+    # scatter sorted tensors to original indexing
+    indices_to_remove = sorted_indices_to_remove.scatter(
+        1, sorted_indices, sorted_indices_to_remove
+    )
+    return logits.masked_fill(indices_to_remove, float("-inf"))
+
+
+def logits_to_probs(
+    logits, mask, temperature=1.0, top_p=0.0, tanh_clipping=0, mask_logits=True
+):
+    """Convert logits to probabilities. Optionally mask logits and apply temperature scaling.
+
+    Args:
+        logits: Logits from the model.
+        mask: Action mask. 1 if feasible, 0 otherwise (so we keep if 1 as done in PyTorch).
+        temperature: Temperature scaling. Higher values make the distribution more uniform (exploration),
+            lower values make it more peaky (exploitation).
+        top_p: Top-p sampling, a.k.a. Nucleus Sampling (https://arxiv.org/abs/1904.09751).
+        tanh_clipping: Tanh clipping (https://arxiv.org/abs/1611.09940).
+        mask_logits: Whether to mask logits of infeasible actions.
+    """
+
+    # Tanh clipping from Bello et al. 2016
+    if tanh_clipping > 0:
+        logits = torch.tanh(logits) * tanh_clipping
+
+    # In RL, we want to mask the logits to prevent the agent from selecting infeasible actions
+    if mask_logits:
+        logits[~mask] = float("-inf")
+
+    logits = logits / temperature  # temperature scaling
+
+    if top_p > 0:
+        assert top_p <= 1.0, "top-p should be in (0, 1]."
+        logits = modify_logits_for_top_p_filtering(logits, top_p)
+
+    # Compute probabilities
+    return torch.softmax(logits, dim=-1)
+
+
 class DecodingStrategy:
     """Base class for decoding strategies. Subclasses should implement the :meth:`_step` method.
     Includes hooks for pre and post main decoding operations.
 
     Args:
+        temperature (float, optional): Temperature scaling. Higher values make the distribution more uniform (exploration),
+            lower values make it more peaky (exploitation). Defaults to 1.0.
+        top_p (float, optional): Top-p sampling, a.k.a. Nucleus Sampling (https://arxiv.org/abs/1904.09751). Defaults to 0.0.
+        mask_logits (bool, optional): Whether to mask logits of infeasible actions. Defaults to True.
+        tanh_clipping (float, optional): Tanh clipping (https://arxiv.org/abs/1611.09940). Defaults to 0.
         multistart (bool, optional): Whether to use multistart decoding. Defaults to False.
         num_starts (int, optional): Number of starts for multistart decoding. Defaults to None.
     """
@@ -44,20 +101,36 @@ class DecodingStrategy:
 
     def __init__(
         self,
+        temperature=1.0,
+        top_p=0.0,
+        mask_logits=True,
+        tanh_clipping=0,
         multistart=False,
         num_starts=None,
         select_start_nodes_fn: callable = None,
         **kwargs,
     ) -> None:
-        self.actions = []
-        self.logp = []
+        self.temperature = temperature
+        self.top_p = top_p
+        self.mask_logits = mask_logits
+        self.tanh_clipping = tanh_clipping
         self.multistart = multistart
         self.num_starts = num_starts
         self.select_start_nodes_fn = select_start_nodes_fn
+        # initialize buffers
+        self.actions = []
+        self.probs = []
 
     def _step(
-        self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
+        self, probs: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
     ) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
+        """Main decoding operation. This method should be called in a loop until all sequences are done.
+
+        Args:
+            probs: Probabilities from the model.
+            mask: Action mask. 1 if feasible, 0 otherwise (so we keep if 1 as done in PyTorch).
+            td: TensorDict containing the current state of the environment.
+        """
         raise NotImplementedError("Must be implemented by subclass")
 
     def pre_decoder_hook(self, td: TensorDict, env: RL4COEnvBase):
@@ -87,11 +160,11 @@ class DecodingStrategy:
 
             td.set("action", action)
             td = env.step(td)["next"]
-            log_p = torch.zeros_like(
+            prob = torch.ones_like(
                 td["action_mask"], device=td.device
-            )  # first log_p is 0, so p = log_p.exp() = 1
+            )  # prob is 1 for the first action
 
-            self.logp.append(log_p)
+            self.probs.append(prob)
             self.actions.append(action)
 
         return td, env, self.num_starts
@@ -99,25 +172,65 @@ class DecodingStrategy:
     def post_decoder_hook(
         self, td: TensorDict, env: RL4COEnvBase
     ) -> Tuple[torch.Tensor, torch.Tensor, TensorDict, RL4COEnvBase]:
+        """Returns the log probabilities, actions, TensorDict and environment after the main decoding operation."""
         assert (
-            len(self.logp) > 0
+            len(self.probs) > 0
         ), "No outputs were collected because all environments were done. Check your initial state"
 
-        return torch.stack(self.logp, 1), torch.stack(self.actions, 1), td, env
+        return torch.stack(self.probs, 1).log(), torch.stack(self.actions, 1), td, env
 
     def step(
-        self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
+        self, logits: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
     ) -> TensorDict:
-        assert not logp.isinf().all(1).any()
+        """Main decoding operation. This method should be called in a loop until all sequences are done.
 
-        logp, selected_actions, td = self._step(logp, mask, td, **kwargs)
-
+        Args:
+            logits: Logits from the model.
+            mask: Action mask. 1 if feasible, 0 otherwise (so we keep if 1 as done in PyTorch).
+            td: TensorDict containing the current state of the environment.
+        """
+        if not self.mask_logits:  # set mask_logit to None if mask_logits is False
+            mask = None
+        probs = logits_to_probs(
+            logits,
+            mask,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            tanh_clipping=self.tanh_clipping,
+            mask_logits=self.mask_logits,
+        )
+        probs, selected_actions, td = self._step(probs, mask, td, **kwargs)
         td.set("action", selected_actions)
-
         self.actions.append(selected_actions)
-        self.logp.append(logp)
-
+        self.probs.append(probs)
         return td
+
+    @staticmethod
+    def greedy(probs, mask=None):
+        """Select the action with the highest probability."""
+        # [BS], [BS]
+        selected = probs.argmax(dim=-1)
+        if mask is not None:
+            assert (
+                not (~mask).gather(1, selected.unsqueeze(-1)).data.any()
+            ), "infeasible action selected"
+
+        return selected
+
+    @staticmethod
+    def sampling(probs, mask=None):
+        """Sample an action with a multinomial distribution given by the log probabilities."""
+        selected = torch.multinomial(probs, 1).squeeze(1)
+
+        if mask is not None:
+            while (~mask).gather(1, selected.unsqueeze(-1)).data.any():
+                log.info("Sampled bad values, resampling!")
+                selected = probs.multinomial(1).squeeze(1)
+            assert (
+                not (~mask).gather(1, selected.unsqueeze(-1)).data.any()
+            ), "infeasible action selected"
+
+        return selected
 
 
 class Greedy(DecodingStrategy):
@@ -127,17 +240,10 @@ class Greedy(DecodingStrategy):
         super().__init__(**kwargs)
 
     def _step(
-        self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
+        self, probs: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
     ) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
-        """Select the action with the highest log probability."""
-        # [BS], [BS]
-        _, selected = logp.max(1)
-
-        assert not mask.gather(
-            1, selected.unsqueeze(-1)
-        ).data.any(), "infeasible action selected"
-
-        return logp, selected, td
+        selected = self.greedy(probs, mask)
+        return probs, selected, td
 
 
 class Sampling(DecodingStrategy):
@@ -147,21 +253,10 @@ class Sampling(DecodingStrategy):
         super().__init__(**kwargs)
 
     def _step(
-        self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
+        self, probs: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
     ) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
-        """Sample an action with a multinomial distribution given by the log probabilities."""
-        probs = logp.exp()
-        selected = torch.multinomial(probs, 1).squeeze(1)
-
-        while mask.gather(1, selected.unsqueeze(-1)).data.any():
-            log.info("Sampled bad values, resampling!")
-            selected = probs.multinomial(1).squeeze(1)
-
-        assert not mask.gather(
-            1, selected.unsqueeze(-1)
-        ).data.any(), "infeasible action selected"
-
-        return logp, selected, td
+        selected = self.sampling(probs, mask)
+        return probs, selected, td
 
 
 class BeamSearch(DecodingStrategy):
@@ -171,23 +266,23 @@ class BeamSearch(DecodingStrategy):
         super().__init__(**kwargs)
         self.beam_width = beam_width
         self.select_best = select_best
-        self.parent_beam_logp = None
+        self.parent_beam_prob = None
         self.beam_path = []
 
     def _step(
-        self, logp: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
+        self, probs: torch.Tensor, mask: torch.Tensor, td: TensorDict, **kwargs
     ) -> Tuple[torch.Tensor, torch.Tensor, TensorDict]:
-        selected, batch_beam_idx = self._make_beam_step(logp)
-        # select the correct state representation, logp and mask according to beam parent
+        selected, batch_beam_idx = self._make_beam_step(probs)
+        # select the correct state representation, prob and mask according to beam parent
         td = td[batch_beam_idx]
-        logp = logp[batch_beam_idx]
+        probs = probs[batch_beam_idx]
         mask = mask[batch_beam_idx]
 
-        assert not mask.gather(
-            1, selected.unsqueeze(-1)
-        ).data.any(), "infeasible action selected"
+        assert (
+            not (~mask).gather(1, selected.unsqueeze(-1)).data.any()
+        ), "infeasible action selected"
 
-        return logp, selected, td
+        return probs, selected, td
 
     def pre_decoder_hook(self, td: TensorDict, env: RL4COEnvBase, **kwargs):
         if self.beam_width is None:
@@ -206,12 +301,12 @@ class BeamSearch(DecodingStrategy):
         td.set("action", action)
         td = env.step(td)["next"]
 
-        log_p = torch.zeros_like(td["action_mask"], device=td.device)
-        beam_parent = torch.zeros(log_p.size(0), device=td.device, dtype=torch.int32)
+        probs = torch.ones_like(td["action_mask"], device=td.device)
+        beam_parent = torch.ones(probs.size(0), device=td.device, dtype=torch.int32)
 
-        self.logp.append(log_p)
+        self.probs.append(probs)
         self.actions.append(action)
-        self.parent_beam_logp = log_p.gather(1, action[..., None])
+        self.parent_beam_probs = probs.gather(1, action[..., None])
         self.beam_path.append(beam_parent)
 
         return td, env, self.beam_width
@@ -229,7 +324,7 @@ class BeamSearch(DecodingStrategy):
         # [BS*BW, seq_len]
         actions = torch.stack(self.actions, 1)
         # [BS*BW, seq_len]
-        logp = torch.stack(self.logp, 1)
+        probs = torch.stack(self.probs, 1)
         assert actions.size(1) == len(
             self.beam_path
         ), "action idx shape and beam path shape dont match"
@@ -238,7 +333,7 @@ class BeamSearch(DecodingStrategy):
         cur_parent = self.beam_path[-1]
         # [BS*BW]
         reversed_aligned_sequences = [actions[:, -1]]
-        reversed_aligned_logp = [logp[:, -1]]
+        reversed_aligned_probs = [probs[:, -1]]
 
         aug_batch_size = actions.size(0)
         batch_size = aug_batch_size // self.beam_width
@@ -250,45 +345,45 @@ class BeamSearch(DecodingStrategy):
             batch_beam_idx = batch_beam_sequence + cur_parent * batch_size
 
             reversed_aligned_sequences.append(actions[batch_beam_idx, k])
-            reversed_aligned_logp.append(logp[batch_beam_idx, k])
+            reversed_aligned_probs.append(probs[batch_beam_idx, k])
             cur_parent = self.beam_path[k][batch_beam_idx]
 
         # [BS*BW, seq_len*num_targets]
         actions = torch.stack(list(reversed(reversed_aligned_sequences)), dim=1)
-        logp = torch.stack(list(reversed(reversed_aligned_logp)), dim=1)
+        probs = torch.stack(list(reversed(reversed_aligned_probs)), dim=1)
 
-        return actions, logp
+        return actions, probs
 
-    def _select_best_beam(self, logp, actions, td: TensorDict, env: RL4COEnvBase):
-        aug_batch_size = logp.size(0)  # num nodes
+    def _select_best_beam(self, probs, actions, td: TensorDict, env: RL4COEnvBase):
+        aug_batch_size = probs.size(0)  # num nodes
         batch_size = aug_batch_size // self.beam_width
         rewards = env.get_reward(td, actions)
         _, idx = torch.cat(rewards.unsqueeze(1).split(batch_size), 1).max(1)
         flat_idx = torch.arange(batch_size, device=rewards.device) + idx * batch_size
-        return logp[flat_idx], actions[flat_idx], td[flat_idx], env
+        return probs[flat_idx], actions[flat_idx], td[flat_idx], env
 
-    def _make_beam_step(self, logp: torch.Tensor):
-        aug_batch_size, num_nodes = logp.shape  # num nodes
+    def _make_beam_step(self, probs: torch.Tensor):
+        aug_batch_size, num_nodes = probs.shape  # num nodes
         batch_size = aug_batch_size // self.beam_width
         batch_beam_sequence = (
-            torch.arange(0, batch_size).repeat(self.beam_width).to(logp.device)
+            torch.arange(0, batch_size).repeat(self.beam_width).to(probs.device)
         )
 
         # [BS*BW, num_nodes] + [BS*BW, 1] -> [BS*BW, num_nodes]
-        log_beam_prob = logp + self.parent_beam_logp  #
+        log_beam_prob = probs + self.parent_beam_probs  #
 
         # [BS, num_nodes * BW]
         log_beam_prob_hstacked = torch.cat(log_beam_prob.split(batch_size), dim=1)
         # [BS, BW]
-        topk_logp, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1)
+        topk_probs, topk_ind = torch.topk(log_beam_prob_hstacked, self.beam_width, dim=1)
 
         # [BS*BW, 1]
-        logp_selected = torch.hstack(torch.unbind(topk_logp, 1)).unsqueeze(1)
+        probs_selected = torch.hstack(torch.unbind(topk_probs, 1)).unsqueeze(1)
 
         # [BS*BW, 1]
         topk_ind = torch.hstack(torch.unbind(topk_ind, 1))
 
-        # since we stack the logprobs from the distinct branches, the indices in
+        # since we stack the prob from the distinct branches, the indices in
         # topk dont correspond to node indices directly and need to be translated
         selected = topk_ind % num_nodes  # determine node index
 
@@ -297,7 +392,7 @@ class BeamSearch(DecodingStrategy):
 
         batch_beam_idx = batch_beam_sequence + beam_parent * batch_size
 
-        self.parent_beam_logp = logp_selected
+        self.parent_beam_probs = probs_selected
         self.beam_path.append(beam_parent)
 
         return selected, batch_beam_idx

--- a/rl4co/models/zoo/common/autoregressive/decoder.py
+++ b/rl4co/models/zoo/common/autoregressive/decoder.py
@@ -9,8 +9,12 @@ from tensordict import TensorDict
 from torch import Tensor
 
 from rl4co.envs import RL4COEnvBase, get_env
-from rl4co.models.nn.attention import LogitAttention
-from rl4co.models.nn.dec_strategies import DecodingStrategy, get_decoding_strategy
+from rl4co.models.nn.attention import PointerAttention
+from rl4co.models.nn.dec_strategies import (
+    DecodingStrategy,
+    get_decoding_strategy,
+    logits_to_probs,
+)
 from rl4co.models.nn.env_embeddings import env_context_embedding, env_dynamic_embedding
 from rl4co.models.nn.env_embeddings.dynamic import StaticEmbedding
 from rl4co.models.nn.utils import get_log_likelihood
@@ -55,6 +59,9 @@ class AutoregressiveDecoder(nn.Module):
         linear_bias: Whether to use a bias in the linear projection of the embeddings
         context_embedding: Module to compute the context embedding. If None, the default is used
         dynamic_embedding: Module to compute the dynamic embedding. If None, the default is used
+        temperature: Temperature for the softmax in the decoder
+        tanh_clipping: Clipping value for the tanh in the decoder
+        mask_logits: Whether to mask the logits in the decoder
     """
 
     def __init__(
@@ -66,7 +73,10 @@ class AutoregressiveDecoder(nn.Module):
         linear_bias: bool = False,
         context_embedding: nn.Module = None,
         dynamic_embedding: nn.Module = None,
-        **logit_attn_kwargs,
+        temperature: float = 1.0,
+        tanh_clipping: float = 10.0,
+        mask_logits: bool = True,
+        **pointer_attn_kwargs,
     ):
         super().__init__()
 
@@ -75,6 +85,9 @@ class AutoregressiveDecoder(nn.Module):
         self.env_name = env_name
         self.embedding_dim = embedding_dim
         self.num_heads = num_heads
+        self.temperature = temperature
+        self.tanh_clipping = tanh_clipping
+        self.mask_logits = mask_logits
 
         assert embedding_dim % num_heads == 0
 
@@ -103,7 +116,7 @@ class AutoregressiveDecoder(nn.Module):
         )
 
         # MHA with Pointer mechanism (https://arxiv.org/abs/1506.03134)
-        self.pointer = LogitAttention(embedding_dim, num_heads, **logit_attn_kwargs)
+        self.pointer = PointerAttention(embedding_dim, num_heads, **pointer_attn_kwargs)
 
     def forward(
         self,
@@ -111,8 +124,10 @@ class AutoregressiveDecoder(nn.Module):
         embeddings: Tensor,
         env: Union[str, RL4COEnvBase] = None,
         decode_type: str = "sampling",
-        softmax_temp: float = None,
         calc_reward: bool = True,
+        temperature: float = None,
+        tanh_clipping: float = None,
+        mask_logits: bool = None,
         **strategy_kwargs,
     ) -> Tuple[Tensor, Tensor, TensorDict]:
         """Forward pass of the decoder
@@ -129,7 +144,6 @@ class AutoregressiveDecoder(nn.Module):
                 - "multistart_sampling": sample as sampling, but with multi-start decoding
                 - "multistart_greedy": sample as greedy, but with multi-start decoding
                 - "beam_search": perform beam search
-            softmax_temp: Temperature for the softmax. If None, default softmax is used from the `LogitAttention` module
             calc_reward: Whether to calculate the reward for the decoded sequence
             strategy_kwargs: Keyword arguments for the decoding strategy. See :class:`rl4co.models.nn.dec_strategies.DecodingStrategy`
 
@@ -146,9 +160,18 @@ class AutoregressiveDecoder(nn.Module):
         # Compute keys, values for the glimpse and keys for the logits once as they can be reused in every step
         cached_embeds = self._precompute_cache(embeddings, td=td)
 
+        # Get default values if not provided
+        temperature = temperature if temperature is not None else self.temperature
+        tanh_clipping = tanh_clipping if tanh_clipping is not None else self.tanh_clipping
+        mask_logits = mask_logits if mask_logits is not None else self.mask_logits
+
         # Setup decoding strategy
         decode_strategy: DecodingStrategy = get_decoding_strategy(
-            decode_type, **strategy_kwargs
+            decode_type,
+            temperature=temperature,
+            tanh_clipping=tanh_clipping,
+            mask_logits=mask_logits,
+            **strategy_kwargs,
         )
 
         # Pre-decoding hook: used for the initial step(s) of the decoding strategy
@@ -156,8 +179,8 @@ class AutoregressiveDecoder(nn.Module):
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():
-            log_p, mask = self._get_log_p(cached_embeds, td, softmax_temp, num_starts)
-            td = decode_strategy.step(log_p, mask, td)
+            logits, mask = self._get_logits(cached_embeds, td, num_starts)
+            td = decode_strategy.step(logits, mask, td)
             td = env.step(td)["next"]
 
         # Post-decoding hook: used for the final step(s) of the decoding strategy
@@ -205,19 +228,17 @@ class AutoregressiveDecoder(nn.Module):
 
         return cached_embeds
 
-    def _get_log_p(
+    def _get_logits(
         self,
         cached: PrecomputedCache,
         td: TensorDict,
-        softmax_temp: float = None,
         num_starts: int = 0,
     ):
-        """Compute the log probabilities of the next actions given the current state
+        """Compute the logits of the next actions given the current state.
 
         Args:
             cache: Precomputed embeddings
             td: TensorDict with the current environment state
-            softmax_temp: Temperature for the softmax
             num_starts: Number of starts for the multi-start decoding
         """
 
@@ -264,18 +285,16 @@ class AutoregressiveDecoder(nn.Module):
         glimpse_v = glimpse_v_stat + glimpse_v_dyn
         logit_k = logit_k_stat + logit_k_dyn
 
-        # Get the mask
-        mask = ~td["action_mask"]
-
         # Compute logits
-        log_p = self.pointer(glimpse_q, glimpse_k, glimpse_v, logit_k, mask, softmax_temp)
+        mask = td["action_mask"]
+        logits = self.pointer(glimpse_q, glimpse_k, glimpse_v, logit_k, mask)
 
-        # Now we need to reshape the logits and log_p to [B*S,N,...] is num_starts > 1 without dynamic embeddings
+        # Now we need to reshape the logits and logits to [B*S,N,...] is num_starts > 1 without dynamic embeddings
         # note that rearranging order is important here
         if num_starts > 1 and not has_dyn_emb_multi_start:
-            log_p = rearrange(log_p, "b s l -> (s b) l", s=num_starts)
+            logits = rearrange(logits, "b s l -> (s b) l", s=num_starts)
             mask = rearrange(mask, "b s l -> (s b) l", s=num_starts)
-        return log_p, mask
+        return logits, mask
 
     def evaluate_action(
         self,
@@ -305,15 +324,21 @@ class AutoregressiveDecoder(nn.Module):
         # Compute keys, values for the glimpse and keys for the logits once as they can be reused in every step
         cached_embeds = self._precompute_cache(embeddings)
 
-        log_p = []
+        probs = []
         decode_step = 0
         while not td["done"].all():
-            log_p_, _ = self._get_log_p(cached_embeds, td)
+            logits, _ = self._get_logits(cached_embeds, td)
+            probs_ = logits_to_probs(
+                logits,
+                td["action_mask"],
+                tanh_clipping=self.tanh_clipping,
+                mask_logits=self.mask_logits,
+            )
             action_ = action[..., decode_step]
 
             td.set("action", action_)
             td = env.step(td)["next"]
-            log_p.append(log_p_)
+            probs.append(probs_)
 
             decode_step += 1
 
@@ -321,7 +346,7 @@ class AutoregressiveDecoder(nn.Module):
         # due to the padded zeros in the actions
 
         # Compute log likelihood of the actions
-        log_p = torch.stack(log_p, 1)  # [batch_size, decoding steps, num_nodes]
+        log_p = torch.stack(probs, 1).log()  # [batch_size, decoding steps, num_nodes]
         ll = get_log_likelihood(
             log_p, action[..., :decode_step], mask=None, return_sum=False
         )  # [batch_size, decoding steps]

--- a/rl4co/models/zoo/common/autoregressive/policy.py
+++ b/rl4co/models/zoo/common/autoregressive/policy.py
@@ -44,6 +44,9 @@ class AutoregressivePolicy(nn.Module):
         train_decode_type: Type of decoding during training
         val_decode_type: Type of decoding during validation
         test_decode_type: Type of decoding during testing
+        temperature: Temperature for the softmax in the decoder
+        tanh_clipping: Clipping value for the tanh in the decoder
+        mask_logits: Whether to mask the logits in the decoder
         **unused_kw: Unused keyword arguments
     """
 
@@ -65,6 +68,9 @@ class AutoregressivePolicy(nn.Module):
         train_decode_type: str = "sampling",
         val_decode_type: str = "greedy",
         test_decode_type: str = "greedy",
+        temperature: float = 1.0,
+        tanh_clipping: float = 10.0,
+        mask_logits: bool = True,
         **unused_kw,
     ):
         super(AutoregressivePolicy, self).__init__()
@@ -100,6 +106,9 @@ class AutoregressivePolicy(nn.Module):
                 mask_inner=mask_inner,
                 context_embedding=context_embedding,
                 dynamic_embedding=dynamic_embedding,
+                temperature=temperature,
+                tanh_clipping=tanh_clipping,
+                mask_logits=mask_logits,
             )
         else:
             self.decoder = decoder

--- a/rl4co/models/zoo/common/nonautoregressive/decoder.py
+++ b/rl4co/models/zoo/common/nonautoregressive/decoder.py
@@ -60,8 +60,8 @@ class EdgeHeatmapGenerator(nn.Module):
             edge_attr = self.act(layer(edge_attr))
         graph.edge_attr = torch.sigmoid(self.output(edge_attr)) * 10  # type: ignore
 
-        heatmaps_logp = self._make_heatmaps(graph)
-        return heatmaps_logp
+        heatmaps_logits = self._make_heatmaps(graph)
+        return heatmaps_logits
 
     def _make_heatmaps(self, batch_graph: Batch) -> Tensor:  # type: ignore
         graphs = batch_graph.to_data_list()
@@ -69,7 +69,7 @@ class EdgeHeatmapGenerator(nn.Module):
         batch_size = len(graphs)
         num_nodes = graphs[0].x.shape[0]
 
-        heatmaps_logp = torch.zeros(
+        heatmaps_logits = torch.zeros(
             (batch_size, num_nodes, num_nodes),
             device=device,
             dtype=graphs[0].edge_attr.dtype,
@@ -77,12 +77,12 @@ class EdgeHeatmapGenerator(nn.Module):
 
         for index, graph in enumerate(graphs):
             edge_index, edge_attr = graph.edge_index, graph.edge_attr
-            heatmaps_logp[index, edge_index[0], edge_index[1]] = edge_attr.flatten()
+            heatmaps_logits[index, edge_index[0], edge_index[1]] = edge_attr.flatten()
 
         if self.undirected_graph:
-            heatmaps_logp = (heatmaps_logp + heatmaps_logp.transpose(1, 2)) * 0.5
+            heatmaps_logits = (heatmaps_logits + heatmaps_logits.transpose(1, 2)) * 0.5
 
-        return heatmaps_logp
+        return heatmaps_logits
 
 
 class NonAutoregressiveDecoder(nn.Module):
@@ -146,7 +146,7 @@ class NonAutoregressiveDecoder(nn.Module):
             env = get_env(env_name)
 
         # calculate heatmap
-        heatmaps_logp = self.heatmap_generator(graph)
+        heatmaps_logits = self.heatmap_generator(graph)
 
         # setup decoding strategy
         self.decode_strategy: DecodingStrategy = get_decoding_strategy(
@@ -156,8 +156,8 @@ class NonAutoregressiveDecoder(nn.Module):
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():
-            log_p, mask = self._get_log_p(td, heatmaps_logp, num_starts)
-            td = self.decode_strategy.step(log_p, mask, td)
+            logits, mask = self._get_logits(td, heatmaps_logits, num_starts)
+            td = self.decode_strategy.step(logits, mask, td)
             td = env.step(td)["next"]
 
         outputs, actions, td, env = self.decode_strategy.post_decoder_hook(td, env)
@@ -168,21 +168,18 @@ class NonAutoregressiveDecoder(nn.Module):
         return outputs, actions, td
 
     @classmethod
-    def _get_log_p(cls, td: TensorDict, heatmaps_logp: Tensor, num_starts: int):
+    def _get_logits(cls, td: TensorDict, heatmaps_logits: Tensor, num_starts: int):
         # Get the mask
-        mask = ~td["action_mask"]
+        action_mask = td["action_mask"]
 
         current_action = td.get("action", None)
         if current_action is None:
-            log_p = heatmaps_logp.mean(-1)
+            logits = heatmaps_logits.mean(-1)
         else:
-            batch_size = heatmaps_logp.shape[0]
+            batch_size = heatmaps_logits.shape[0]
             _indexer = cls._multistart_batched_index(batch_size, num_starts)
-            log_p = heatmaps_logp[_indexer, current_action, :]
-
-        log_p[mask] = -torch.inf
-        log_p = nn.functional.log_softmax(log_p, -1)
-        return log_p, mask
+            logits = heatmaps_logits[_indexer, current_action, :]
+        return logits, action_mask
 
     @staticmethod
     @lru_cache(10)

--- a/rl4co/models/zoo/common/nonautoregressive/decoder.py
+++ b/rl4co/models/zoo/common/nonautoregressive/decoder.py
@@ -62,6 +62,8 @@ class EdgeHeatmapGenerator(nn.Module):
 
         heatmaps_logits = self._make_heatmaps(graph)
         return heatmaps_logits
+        heatmaps_logits = self._make_heatmaps(graph)
+        return heatmaps_logits
 
     def _make_heatmaps(self, batch_graph: Batch) -> Tensor:  # type: ignore
         graphs = batch_graph.to_data_list()
@@ -156,8 +158,8 @@ class NonAutoregressiveDecoder(nn.Module):
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():
-            logits, mask = self._get_logits(td, heatmaps_logits, num_starts)
-            td = self.decode_strategy.step(logits, mask, td)
+            log_p, mask = self._get_log_p(td, heatmaps_logits, num_starts)
+            td = decode_strategy.step(log_p, mask, td)
             td = env.step(td)["next"]
 
         outputs, actions, td, env = decode_strategy.post_decoder_hook(td, env)

--- a/rl4co/models/zoo/common/nonautoregressive/decoder.py
+++ b/rl4co/models/zoo/common/nonautoregressive/decoder.py
@@ -149,10 +149,10 @@ class NonAutoregressiveDecoder(nn.Module):
         heatmaps_logits = self.heatmap_generator(graph)
 
         # setup decoding strategy
-        self.decode_strategy: DecodingStrategy = get_decoding_strategy(
+        decode_strategy: DecodingStrategy = get_decoding_strategy(
             decode_type, **strategy_kwargs
         )
-        td, env, num_starts = self.decode_strategy.pre_decoder_hook(td, env)
+        td, env, num_starts = decode_strategy.pre_decoder_hook(td, env)
 
         # Main decoding: loop until all sequences are done
         while not td["done"].all():
@@ -160,7 +160,7 @@ class NonAutoregressiveDecoder(nn.Module):
             td = self.decode_strategy.step(logits, mask, td)
             td = env.step(td)["next"]
 
-        outputs, actions, td, env = self.decode_strategy.post_decoder_hook(td, env)
+        outputs, actions, td, env = decode_strategy.post_decoder_hook(td, env)
 
         if calc_reward:
             td.set("reward", env.get_reward(td, actions))

--- a/rl4co/models/zoo/deepaco/antsystem.py
+++ b/rl4co/models/zoo/deepaco/antsystem.py
@@ -118,14 +118,15 @@ class AntSystem:
     ):
         # Sample from heatmaps
         # p = phe**alpha * heu**beta <==> log(p) = alpha*log(phe) + beta*log(heu)
-        heatmaps_logp = (
+        heatmaps_logits = (
             self.alpha * torch.log(self.pheromone) + self.beta * self.log_heuristic
         )
         self.decode_strategy = Sampling(multistart=True, num_starts=self.n_ants)
         td, env, num_starts = self.decode_strategy.pre_decoder_hook(td, env)
         while not td["done"].all():
-            log_p, mask = NARDecoder._get_log_p(td, heatmaps_logp, num_starts)
-            td = self.decode_strategy.step(log_p, mask, td)
+            logits, mask = NARDecoder._get_logits(td, heatmaps_logits, num_starts)
+            td = self.decode_strategy.step(logits, mask, td)
+            # TODO: check, do we need to run the logits normalization via step here?
             td = env.step(td)["next"]
 
         outputs, actions, td, env = self.decode_strategy.post_decoder_hook(td, env)

--- a/rl4co/models/zoo/deepaco/antsystem.py
+++ b/rl4co/models/zoo/deepaco/antsystem.py
@@ -121,15 +121,15 @@ class AntSystem:
         heatmaps_logits = (
             self.alpha * torch.log(self.pheromone) + self.beta * self.log_heuristic
         )
-        self.decode_strategy = Sampling(multistart=True, num_starts=self.n_ants)
-        td, env, num_starts = self.decode_strategy.pre_decoder_hook(td, env)
+        decode_strategy = Sampling(multistart=True, num_starts=self.n_ants)
+        td, env, num_starts = decode_strategy.pre_decoder_hook(td, env)
         while not td["done"].all():
             logits, mask = NARDecoder._get_logits(td, heatmaps_logits, num_starts)
-            td = self.decode_strategy.step(logits, mask, td)
+            td = decode_strategy.step(logits, mask, td)
             # TODO: check, do we need to run the logits normalization via step here?
             td = env.step(td)["next"]
 
-        outputs, actions, td, env = self.decode_strategy.post_decoder_hook(td, env)
+        outputs, actions, td, env = decode_strategy.post_decoder_hook(td, env)
         reward = env.get_reward(td, actions)
 
         if self.require_logp:

--- a/rl4co/models/zoo/deepaco/decoder.py
+++ b/rl4co/models/zoo/deepaco/decoder.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Type, Union
 
 import torch.nn as nn
 
@@ -39,7 +39,7 @@ class DeepACODecoder(NonAutoregressiveDecoder):
         num_layers: int,
         heatmap_generator: Optional[nn.Module] = None,
         linear_bias: bool = True,
-        aco_class=AntSystem,
+        aco_class: Optional[Type[AntSystem]] = None,
         n_ants: Optional[Union[int, dict]] = None,
         n_iterations: Optional[Union[int, dict]] = None,
         **aco_args,
@@ -51,7 +51,7 @@ class DeepACODecoder(NonAutoregressiveDecoder):
             heatmap_generator=heatmap_generator,
             linear_bias=linear_bias,
         )
-        self.aco_class = aco_class
+        self.aco_class = AntSystem if aco_class is None else aco_class
         self.aco_args = aco_args
         self.n_ants = merge_with_defaults(n_ants, train=20, val=20, test=20)
         self.n_iterations = merge_with_defaults(n_iterations, train=1, val=20, test=100)

--- a/rl4co/models/zoo/deepaco/model.py
+++ b/rl4co/models/zoo/deepaco/model.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from rl4co.envs.common.base import RL4COEnvBase
 from rl4co.models.rl import REINFORCE
@@ -11,6 +11,7 @@ class DeepACO(REINFORCE):
 
     Args:
         env: Environment to use for the algorithm
+        policy: Policy to use for the algorithm
         baseline: REINFORCE baseline. Defaults to exponential
         policy_kwargs: Keyword arguments for policy
         baseline_kwargs: Keyword arguments for baseline
@@ -20,11 +21,13 @@ class DeepACO(REINFORCE):
     def __init__(
         self,
         env: RL4COEnvBase,
+        policy: Optional[DeepACOPolicy] = None,
         baseline: Union[REINFORCEBaseline, str] = "exponential",
         policy_kwargs: dict = {},
         baseline_kwargs: dict = {},
         **kwargs,
     ):
-        policy = DeepACOPolicy(env.name, **policy_kwargs)
+        if policy is None:
+            policy = DeepACOPolicy(env.name, **policy_kwargs)
 
         super().__init__(env, policy, baseline, baseline_kwargs, **kwargs)

--- a/rl4co/models/zoo/eas/search.py
+++ b/rl4co/models/zoo/eas/search.py
@@ -12,7 +12,7 @@ from torch.utils.data import Dataset
 from rl4co.data.transforms import StateAugmentation
 from rl4co.models.nn.utils import get_log_likelihood
 from rl4co.models.zoo.common.search import SearchBase
-from rl4co.models.zoo.eas.decoder import forward_eas, forward_logit_attn_eas_lay
+from rl4co.models.zoo.eas.decoder import forward_eas, forward_pointer_attn_eas_lay
 from rl4co.models.zoo.eas.nn import EASLayerNet
 from rl4co.utils.ops import batchify, gather_by_index, unbatchify
 from rl4co.utils.pylogger import get_pylogger
@@ -166,7 +166,9 @@ class EAS(SearchBase):
             # EASLay: replace forward of logit attention computation. EASLayer
             eas_layer = EASLayerNet(num_instances, decoder.embedding_dim).to(batch.device)
             decoder.pointer.eas_layer = partial(eas_layer, decoder.pointer)
-            decoder.pointer.forward = partial(forward_logit_attn_eas_lay, decoder.pointer)
+            decoder.pointer.forward = partial(
+                forward_pointer_attn_eas_lay, decoder.pointer
+            )
             for param in eas_layer.parameters():
                 opt_params.append(param)
         if self.hparams.use_eas_embedding:

--- a/rl4co/models/zoo/eas/search.py
+++ b/rl4co/models/zoo/eas/search.py
@@ -165,12 +165,8 @@ class EAS(SearchBase):
         if self.hparams.use_eas_layer:
             # EASLay: replace forward of logit attention computation. EASLayer
             eas_layer = EASLayerNet(num_instances, decoder.embedding_dim).to(batch.device)
-            decoder.logit_attention.eas_layer = partial(
-                eas_layer, decoder.logit_attention
-            )
-            decoder.logit_attention.forward = partial(
-                forward_logit_attn_eas_lay, decoder.logit_attention
-            )
+            decoder.pointer.eas_layer = partial(eas_layer, decoder.pointer)
+            decoder.pointer.forward = partial(forward_logit_attn_eas_lay, decoder.pointer)
             for param in eas_layer.parameters():
                 opt_params.append(param)
         if self.hparams.use_eas_embedding:

--- a/rl4co/models/zoo/mdam/decoder.py
+++ b/rl4co/models/zoo/mdam/decoder.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 from tensordict import TensorDict
 
 from rl4co.envs import RL4COEnvBase
-from rl4co.models.nn.attention import LogitAttention
+from rl4co.models.nn.attention import PointerAttention
 from rl4co.models.nn.env_embeddings import env_context_embedding, env_dynamic_embedding
 from rl4co.models.nn.utils import decode_probs, get_log_likelihood
 
@@ -88,7 +88,7 @@ class Decoder(nn.Module):
 
         # MHA with Pointer mechanism (https://arxiv.org/abs/1506.03134)
         self.pointer = [
-            LogitAttention(
+            PointerAttention(
                 embedding_dim,
                 num_heads,
                 mask_inner=mask_inner,

--- a/rl4co/models/zoo/mdam/decoder.py
+++ b/rl4co/models/zoo/mdam/decoder.py
@@ -6,6 +6,7 @@ from typing import Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from tensordict import TensorDict
 
 from rl4co.envs import RL4COEnvBase
@@ -85,7 +86,8 @@ class Decoder(nn.Module):
             env_name, {"embedding_dim": embedding_dim}
         )
 
-        self.logit_attention = [
+        # MHA with Pointer mechanism (https://arxiv.org/abs/1506.03134)
+        self.pointer = [
             LogitAttention(
                 embedding_dim,
                 num_heads,
@@ -276,7 +278,6 @@ class Decoder(nn.Module):
         mask = ~td["action_mask"]
 
         # Compute logits (unnormalized log_p)
-        # log_p, _ = self.logit_attention[path_index](glimpse_q, glimpse_k, glimpse_v, logit_k, mask, path_index)
         log_p, _ = self._one_to_many_logits(
             glimpse_q, glimpse_k, glimpse_v, logit_k, mask, path_index
         )

--- a/rl4co/models/zoo/ptrnet/decoder.py
+++ b/rl4co/models/zoo/ptrnet/decoder.py
@@ -157,7 +157,8 @@ class Decoder(nn.Module):
             )
             # select the next inputs for the decoder [batch_size x hidden_dim]
             idxs = (
-                decode_probs(probs, mask, decode_type=decode_type)
+                # note: mask here is the inverse of usual action mask
+                decode_probs(probs, ~mask, decode_type=decode_type)
                 if eval_tours is None
                 else eval_tours[:, i]
             )


### PR DESCRIPTION
## Description

Several refactorings and features made for decoding in RL4CO.

1. [Refactoring] Now models return logits by default (e.g. [here](https://github.com/ai4co/rl4co/blob/2c6984f4d9bd68252341347abd6c2cb0f80fdf27/rl4co/models/nn/attention.py#L177)). We do so since logits represent the raw outputs from the model, and we would like to decouple the modeling part to how we sample distributions. The function handling the transfer from logits to probabilities (hence the "log_p") is [`logit_to_probs`](https://github.com/ai4co/rl4co/blob/2c6984f4d9bd68252341347abd6c2cb0f80fdf27/rl4co/models/nn/dec_strategies.py#L53) 
2. [Feat] New decoding strategy: we introduce [nucleus sampling](https://arxiv.org/abs/1904.09751) (i.e. top-p sampling) which discards from the distribution values under a certain threshold in the CDF before sampling. This can be used by simply passing a `top_p`  > 0 to the `DecodingStrategy`, i.e. to the model deooder. This is ubiquitous in LLMs and it is about time to have it!
3. [Refactoring]: for simplicity we now default to **handling probabilities instead of log probabilities** (example [here](https://github.com/ai4co/rl4co/blob/2c6984f4d9bd68252341347abd6c2cb0f80fdf27/rl4co/models/nn/dec_strategies.py#L202C10-L202C11)). This is a minor change, but it can make the code more readable and avoid having to do `logp.exp()` when sampling. This is also more in line with recent works in e.g. LLM
4. [Refactoring, **breaking change**] now by default **any mask has the same behavior** (example [here](https://github.com/ai4co/rl4co/blob/2c6984f4d9bd68252341347abd6c2cb0f80fdf27/rl4co/models/nn/dec_strategies.py#L72)), i.e., the value 1 means keep (i.e. feasible action) while 0 means to remove, i.e. infeasible. This is both similar to TorchRL's action mask and importantly to PyTorch's `scaled_dot_product_attention`: "A boolean mask where a value of True indicates that the element should take part in attention. " ([ref](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html#:~:text=A%20boolean%20mask%20where%20a%20value%20of%20True%20indicates%20that%20the%20element%20should%20take%20part%20in%20attention.)). For this reason, masks that used to have inconsistent namings now have the same behavior
5. [Minor] Rename `LogitAttention` to [`PointerAttention`](https://github.com/ai4co/rl4co/blob/2c6984f4d9bd68252341347abd6c2cb0f80fdf27/rl4co/models/nn/attention.py#L133) (for consistency with the Pointer mechanism in [Vinyals et al., 2015](https://arxiv.org/abs/1506.03134))

> [!WARNING]
> Work in progress. Do not merge yet. Some checks and training still have some bugs that need to be fixed (most probably due to the new masking


## Types of changes

- [x] New feature (non-breaking change which adds core functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.


---

CC: @LTluttmann could you have a look if you spot some inefficiencies or if you have some ideas?
CC: @Furffico @cbhua these changess are what I was talking about yesterday (note that in this case running the softmax normalization inside the[ `Sampling` ](https://github.com/ai4co/rl4co/blob/2c6984f4d9bd68252341347abd6c2cb0f80fdf27/rl4co/models/zoo/deepaco/antsystem.py#L124)in ACO might not be needed)