### PR TITLE
[Enhancement, Minor] Fix the `visited` shape of CVRP

### DIFF
--- a/rl4co/envs/routing/cvrptw/env.py
+++ b/rl4co/envs/routing/cvrptw/env.py
@@ -159,7 +159,7 @@ class CVRPTWEnv(CVRPEnv):
                     (*batch_size, 1), self.generator.vehicle_capacity, device=device
                 ),
                 "visited": torch.zeros(
-                    (*batch_size, 1, td["locs"].shape[-2] + 1),
+                    (*batch_size, td["locs"].shape[-2] + 1),
                     dtype=torch.uint8,
                     device=device,
                 ),


### PR DESCRIPTION
## Description

In CVRP and CVRPTW, previously the size of `visited` is `[batch_size, 1, num_node]`. Now the size of `visited` is changed to `[batch_size, num_node]`.

## Motivation and Context

All other environments use the size of `visited` with `[batch_size, num_node]`. Change the CVRP and CVRPTW's for the consequence. 

Also, the previous size `[batch_size, 1, num_node]` introduced a few expanding and squeezing operations, which are a bit massive and hard to read. Using the size of  `[batch_size, num_node]` could make the code clean. 

## Types of changes

- [x] Minor enhancement. Create this PR just in case there is a special reason to use the previous size: `[batch_size, 1, num_node]`

## Checklist

- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).