### PR TITLE
[Minor] Am decoder refactor

### DIFF
--- a/configs/model/pomo.yaml
+++ b/configs/model/pomo.yaml
@@ -6,5 +6,5 @@ num_augment: 8
 metrics:
   train: ["loss", "reward"]
   val: ["reward", "max_reward", "max_aug_reward"]
-  test: ${metrics.val}
+  test: ${model.metrics.val}
   log_on_step: True


### PR DESCRIPTION
## Description

Refactoring of the Attention model's decoder. 

## Motivation and Context

By outsourcing the computation of glimpse_<q,k,v> and logit_k tensors into separate functions, we allow for more flexibility when reusing this decoder for other models. In scheduling for example, we need to select the embedding of the next operation for each job. This can now be achieved by simply overwriting the `_comput_kvl`function. 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.