### PR TITLE
[BugFix] solve memory leakage during autoregressive decoding

### DIFF
--- a/rl4co/__init__.py
+++ b/rl4co/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.1dev0"
+__version__ = "0.4.1dev1"

--- a/rl4co/models/common/constructive/base.py
+++ b/rl4co/models/common/constructive/base.py
@@ -212,6 +212,7 @@ class ConstructivePolicy(nn.Module):
             temperature=decoding_kwargs.pop("temperature", self.temperature),
             tanh_clipping=decoding_kwargs.pop("tanh_clipping", self.tanh_clipping),
             mask_logits=decoding_kwargs.pop("mask_logits", self.mask_logits),
+            only_store_selected_logp=not return_entropy,
             **decoding_kwargs,
         )
 

--- a/rl4co/models/common/constructive/base.py
+++ b/rl4co/models/common/constructive/base.py
@@ -212,7 +212,7 @@ class ConstructivePolicy(nn.Module):
             temperature=decoding_kwargs.pop("temperature", self.temperature),
             tanh_clipping=decoding_kwargs.pop("tanh_clipping", self.tanh_clipping),
             mask_logits=decoding_kwargs.pop("mask_logits", self.mask_logits),
-            only_store_selected_logp=not return_entropy,
+            store_all_logp=decoding_kwargs.pop("store_all_logp", return_entropy),
             **decoding_kwargs,
         )
 

--- a/rl4co/models/rl/ppo/ppo.py
+++ b/rl4co/models/rl/ppo/ppo.py
@@ -72,7 +72,7 @@ class PPO(RL4COLitModule):
         normalize_adv: bool = False,  # whether to normalize advantage
         max_grad_norm: float = 0.5,  # max gradient norm
         metrics: dict = {
-            "train": ["loss", "surrogate_loss", "value_loss", "entropy"],
+            "train": ["reward", "loss", "surrogate_loss", "value_loss", "entropy"],
         },
         **kwargs,
     ):

--- a/rl4co/models/zoo/ptrnet/decoder.py
+++ b/rl4co/models/zoo/ptrnet/decoder.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from rl4co.utils.decoding import decode_logprobs
+from rl4co.utils.ops import gather_by_index
 
 
 class SimpleAttention(nn.Module):
@@ -160,11 +161,12 @@ class Decoder(nn.Module):
                 if eval_tours is None
                 else eval_tours[:, i]
             )
+            # select logp of chosen action
+            log_p = gather_by_index(log_p, idxs, dim=1)
 
             idxs = (
                 idxs.detach()
             )  # Otherwise pytorch complains it want's a reward, todo implement this more properly?
-
             # Gather input embedding of selected
             decoder_input = torch.gather(
                 embedded_inputs,

--- a/rl4co/utils/decoding.py
+++ b/rl4co/utils/decoding.py
@@ -285,7 +285,10 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
             td.set("action", action)
             td = env.step(td)["next"]
             # first logprobs is 0, so p = logprobs.exp() = 1
-            logprobs = torch.zeros_like(action, device=td.device)
+            if self.store_all_logp:
+                logprobs = torch.zeros_like(td["action_mask"])  # [B, N]
+            else:
+                logprobs = torch.zeros_like(action, device=td.device)  # [B]
 
             self.logprobs.append(logprobs)
             self.actions.append(action)

--- a/rl4co/utils/decoding.py
+++ b/rl4co/utils/decoding.py
@@ -218,7 +218,7 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
         num_starts: Optional[int] = None,
         select_start_nodes_fn: Optional[callable] = None,
         select_best: bool = False,
-        only_store_selected_logp: bool = True,
+        store_all_logp: bool = False,
         **kwargs,
     ) -> None:
         self.temperature = temperature
@@ -230,7 +230,7 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
         self.num_starts = num_starts
         self.select_start_nodes_fn = select_start_nodes_fn
         self.select_best = select_best
-        self.only_store_selected_logp = only_store_selected_logp
+        self.store_all_logp = store_all_logp
         # initialize buffers
         self.actions = []
         self.logprobs = []
@@ -335,7 +335,7 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
         logprobs, selected_action, td = self._step(
             logprobs, mask, td, action=action, **kwargs
         )
-        if self.only_store_selected_logp:
+        if not self.store_all_logp:
             logprobs = gather_by_index(logprobs, selected_action, dim=1)
         td.set("action", selected_action)
         self.actions.append(selected_action)
@@ -424,7 +424,7 @@ class BeamSearch(DecodingStrategy):
 
     def __init__(self, beam_width=None, select_best=True, **kwargs) -> None:
         # TODO do we really need all logp in beam search?
-        kwargs["only_store_selected_logp"] = False
+        kwargs["store_all_logp"] = True
         super().__init__(**kwargs)
         self.beam_width = beam_width
         self.select_best = select_best

--- a/rl4co/utils/decoding.py
+++ b/rl4co/utils/decoding.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from tensordict.tensordict import TensorDict
 
 from rl4co.envs import RL4COEnvBase
-from rl4co.utils.ops import batchify, unbatchify, unbatchify_and_gather
+from rl4co.utils.ops import batchify, gather_by_index, unbatchify, unbatchify_and_gather
 from rl4co.utils.pylogger import get_pylogger
 
 log = get_pylogger(__name__)
@@ -35,7 +35,7 @@ def get_decoding_strategy(decoding_strategy, **config):
     return strategy_registry.get(decoding_strategy, Sampling)(**config)
 
 
-def get_log_likelihood(logprobs, actions, mask=None, return_sum: bool = True):
+def get_log_likelihood(logprobs, actions=None, mask=None, return_sum: bool = True):
     """Get log likelihood of selected actions.
     Note that mask is a boolean tensor where True means the value should be kept.
 
@@ -45,7 +45,9 @@ def get_log_likelihood(logprobs, actions, mask=None, return_sum: bool = True):
         mask: Action mask. 1 if feasible, 0 otherwise (so we keep if 1 as done in PyTorch).
         return_sum: Whether to return the sum of log probabilities or not. Defaults to True.
     """
-    logprobs = logprobs.gather(-1, actions.unsqueeze(-1)).squeeze(-1)
+    # Optional: select logp when logp.shape = (bs, dec_steps, N)
+    if actions is not None and logprobs.dim() == 3:
+        logprobs = logprobs.gather(-1, actions.unsqueeze(-1)).squeeze(-1)
 
     # Optional: mask out actions irrelevant to objective so they do not get reinforced
     if mask is not None:
@@ -216,6 +218,7 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
         num_starts: Optional[int] = None,
         select_start_nodes_fn: Optional[callable] = None,
         select_best: bool = False,
+        only_store_selected_logp: bool = True,
         **kwargs,
     ) -> None:
         self.temperature = temperature
@@ -227,6 +230,7 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
         self.num_starts = num_starts
         self.select_start_nodes_fn = select_start_nodes_fn
         self.select_best = select_best
+        self.only_store_selected_logp = only_store_selected_logp
         # initialize buffers
         self.actions = []
         self.logprobs = []
@@ -280,9 +284,8 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
 
             td.set("action", action)
             td = env.step(td)["next"]
-            logprobs = torch.zeros_like(
-                td["action_mask"], device=td.device
-            )  # first logprobs is 0, so p = logprobs.exp() = 1
+            # first logprobs is 0, so p = logprobs.exp() = 1
+            logprobs = torch.zeros_like(action, device=td.device)
 
             self.logprobs.append(logprobs)
             self.actions.append(action)
@@ -332,6 +335,8 @@ class DecodingStrategy(metaclass=abc.ABCMeta):
         logprobs, selected_action, td = self._step(
             logprobs, mask, td, action=action, **kwargs
         )
+        if self.only_store_selected_logp:
+            logprobs = gather_by_index(logprobs, selected_action, dim=1)
         td.set("action", selected_action)
         self.actions.append(selected_action)
         self.logprobs.append(logprobs)
@@ -418,6 +423,8 @@ class BeamSearch(DecodingStrategy):
     name = "beam_search"
 
     def __init__(self, beam_width=None, select_best=True, **kwargs) -> None:
+        # TODO do we really need all logp in beam search?
+        kwargs["only_store_selected_logp"] = False
         super().__init__(**kwargs)
         self.beam_width = beam_width
         self.select_best = select_best


### PR DESCRIPTION
## Description

By not keeping only the logprobs of selected actions but all logprobs in the buffer of the decoding strategies, memory issues might occur. This is now fixed by adding an additional parameter `only_store_selected_logp` to the base decoding strategy, which defaults to True. Only exception is when we require the computation of the entropy (as in PPO). 
This fix should be backward compatible. We can still pass all logprobs to the `get_log_likelihood` function along with the actions, in which case this functions gathers the correct logprobs (like before).

## Motivation and Context

see above

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.