### PR TITLE
[BugFix] Fix a bug in the augmentation of FFSP instances

### DIFF
--- a/configs/experiment/scheduling/ffsp-matnet.yaml
+++ b/configs/experiment/scheduling/ffsp-matnet.yaml
@@ -1,0 +1,46 @@
+# @package _global_
+
+defaults:
+  - override /model: matnet.yaml
+  - override /callbacks: default.yaml
+  - override /trainer: default.yaml
+  - override /logger: wandb.yaml
+  - override /env: ffsp.yaml
+
+logger:
+  wandb:
+    project: "rl4co"
+    log_model: "all"
+    group: "${env.name}-${env.generator_params.num_job}-${env.generator_params.num_machine}"
+    tags: ["matnet", "${env.name}"]
+    name: "matnet-${env.name}-${env.generator_params.num_job}j-${env.generator_params.num_machine}m"
+
+env:
+  generator_params:
+    num_stage: 3
+    num_machine: 4
+    num_job: 20
+    flatten_stages: False
+
+trainer:
+  max_epochs: 50
+  # NOTE for some reason l2d is extremely sensitive to precision
+  # ONLY USE 32-true for l2d!
+  precision: 32-true
+  gradient_clip_val: 10 # orig paper does not use grad clipping
+
+seed: 12345678
+
+model:
+  batch_size: 50
+  train_data_size: 10_000
+  val_data_size: 1_000
+  test_data_size: 1_000
+  optimizer_kwargs:
+    lr: 1e-4
+    weight_decay: 1e-6
+  lr_scheduler:
+    "MultiStepLR"
+  lr_scheduler_kwargs:
+    milestones: [35, 45]
+    gamma: 0.1

--- a/rl4co/data/dataset.py
+++ b/rl4co/data/dataset.py
@@ -6,6 +6,27 @@ from tensordict.tensordict import TensorDict
 from torch.utils.data import Dataset
 
 
+class FastTdDataset(Dataset):
+    """
+    Note:
+        Check out the issue on tensordict for more details:
+        https://github.com/pytorch-labs/tensordict/issues/374.
+    """
+
+    def __init__(self, td: TensorDict):
+        self.data_len = td.batch_size[0]
+        self.data = td
+
+    def __len__(self):
+        return self.data_len
+
+    def __getitems__(self, idx):
+        return self.data[idx]
+
+    def add_key(self, key, value):
+        return ExtraKeyDataset(self, value, key_name=key)
+
+
 class TensorDictDataset(Dataset):
     """Dataset compatible with TensorDicts with low CPU usage.
     Fast loading but somewhat slow instantiation due to list comprehension since we

--- a/rl4co/data/dataset.py
+++ b/rl4co/data/dataset.py
@@ -26,6 +26,11 @@ class FastTdDataset(Dataset):
     def add_key(self, key, value):
         return ExtraKeyDataset(self, value, key_name=key)
 
+    @staticmethod
+    def collate_fn(batch: Union[dict, TensorDict]):
+        """Collate function compatible with TensorDicts that reassembles a list of dicts."""
+        return batch
+
 
 class TensorDictDataset(Dataset):
     """Dataset compatible with TensorDicts with low CPU usage.

--- a/rl4co/envs/common/base.py
+++ b/rl4co/envs/common/base.py
@@ -8,7 +8,7 @@ import torch
 from tensordict.tensordict import TensorDict
 from torchrl.envs import EnvBase
 
-from rl4co.data.dataset import TensorDictDataset
+from rl4co.data.dataset import FastTdDataset
 from rl4co.data.utils import load_npz_to_tensordict
 from rl4co.utils.ops import get_num_starts, select_start_nodes
 from rl4co.utils.pylogger import get_pylogger
@@ -52,7 +52,7 @@ class RL4COEnvBase(EnvBase, metaclass=abc.ABCMeta):
         val_dataloader_names: list = None,
         test_dataloader_names: list = None,
         check_solution: bool = True,
-        dataset_cls: callable = TensorDictDataset,
+        dataset_cls: callable = FastTdDataset,
         seed: int = None,
         device: str = "cpu",
         batch_size: torch.Size = None,

--- a/rl4co/envs/common/base.py
+++ b/rl4co/envs/common/base.py
@@ -8,7 +8,7 @@ import torch
 from tensordict.tensordict import TensorDict
 from torchrl.envs import EnvBase
 
-from rl4co.data.dataset import FastTdDataset
+from rl4co.data.dataset import TensorDictDataset
 from rl4co.data.utils import load_npz_to_tensordict
 from rl4co.utils.ops import get_num_starts, select_start_nodes
 from rl4co.utils.pylogger import get_pylogger
@@ -52,7 +52,7 @@ class RL4COEnvBase(EnvBase, metaclass=abc.ABCMeta):
         val_dataloader_names: list = None,
         test_dataloader_names: list = None,
         check_solution: bool = True,
-        dataset_cls: callable = FastTdDataset,
+        dataset_cls: callable = TensorDictDataset,
         seed: int = None,
         device: str = "cpu",
         batch_size: torch.Size = None,

--- a/rl4co/envs/scheduling/ffsp/generator.py
+++ b/rl4co/envs/scheduling/ffsp/generator.py
@@ -1,17 +1,9 @@
-import os
-import zipfile
-from typing import Union, Callable
-
 import torch
-import numpy as np
 
-from robust_downloader import download
-from torch.distributions import Uniform
 from tensordict.tensordict import TensorDict
 
-from rl4co.data.utils import load_npz_to_tensordict
+from rl4co.envs.common.utils import Generator
 from rl4co.utils.pylogger import get_pylogger
-from rl4co.envs.common.utils import get_sampler, Generator
 
 log = get_pylogger(__name__)
 
@@ -34,6 +26,7 @@ class FFSPGenerator(Generator):
     Note:
         - [IMPORTANT] This version of ffsp requires the number of machines in each stage to be the same
     """
+
     def __init__(
         self,
         num_stage: int = 2,
@@ -42,7 +35,7 @@ class FFSPGenerator(Generator):
         min_time: int = 2,
         max_time: int = 10,
         flatten_stages: bool = True,
-        **unused_kwargs
+        **unused_kwargs,
     ):
         self.num_stage = num_stage
         self.num_machine = num_machine
@@ -61,15 +54,8 @@ class FFSPGenerator(Generator):
         run_time = torch.randint(
             low=self.min_time,
             high=self.max_time,
-            size=(*batch_size, self.num_job, self.num_machine, self.num_stage),
+            size=(*batch_size, self.num_job, self.num_machine_total),
         )
-
-        if self.flatten_stages:
-            run_time = (
-                run_time.transpose(-2, -1)
-                .contiguous()
-                .view(*batch_size, self.num_job, self.num_machine_total)
-            )
 
         return TensorDict(
             {


### PR DESCRIPTION
## Description

Fixes a bug in the augmentation of a FFSP instance, where stages were assigned the wrong machines in the `pre_step` of the environment. 

Also added marginally faster tensordict dataset which uses slightly (around 30%) more CPU and improved the MatNet code a little bit.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/ai4co/rl4co/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.