### PR TITLE
[BugFix]fix kwargs in initializing ProblemData object

### DIFF
--- a/rl4co/envs/routing/cvrp/local_search.py
+++ b/rl4co/envs/routing/cvrp/local_search.py
@@ -164,8 +164,8 @@ def make_data(
                 name=",".join(map(str, range(1, len(positions)))),
             )
         ],
-        distance_matrix=distances,
-        duration_matrix=np.zeros_like(distances),
+        distance_matrices=[distances],
+        duration_matrices=[np.zeros_like(distances)],
     )
 
 


### PR DESCRIPTION
## Description

Fix chunk that calls local search for CVRP.
At current project, calling `CVRPEnv.local_search` raises error.  #212 
This is because the names  and  type of kwargs 
passed to `ProblemData` is wrong, and result in failing to instantiate `ProblemData` object.
Please check this lines!!
https://github.com/PyVRP/PyVRP/blob/9be2b6422230e4f3781b0d10388274cb1dda10db/pyvrp/_pyvrp.pyi#L155-L156

I tried to call local search for cvrp after applying the patch in this PR and it works.
## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [x] I have raised an issue to propose this change ([required](https://github.com/ai4co/rl4co/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.