### PR TITLE
bugfix: restrict upper version of tensordict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ pyrootutils = "*"
 rich = "*"
 robust-downloader = "*"
 scipy = "*"
-tensordict = ">=0.4.0"
+tensordict = ">=0.4.0, <0.6.0"
 torchrl = ">=0.4.0"
 wandb = "*"
 # Dev dependencies


### PR DESCRIPTION
## Description

This is temporal patch for #229 

## Motivation and Context
Work around to avoid #229 , but this change restrict upper-version of dependency.

- [ ] I have raised an issue to propose this change ([required](https://github.com/ai4co/rl4co/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.