### PR TITLE
Update CVRPTW generator scaling

### DIFF
--- a/rl4co/envs/routing/cvrptw/generator.py
+++ b/rl4co/envs/routing/cvrptw/generator.py
@@ -134,8 +134,8 @@ class CVRPTWGenerator(CVRPGenerator):
             durations = durations / self.max_time
             min_times = min_times / self.max_time
             max_times = max_times / self.max_time
-            td["depot"] = td["depot"] / self.max_time
-            td["locs"] = td["locs"] / self.max_time
+            td["depot"] = td["depot"] / self.max_log
+            td["locs"] = td["locs"] / self.max_log
 
         # 8. stack to tensor time_windows
         time_windows = torch.stack((min_times, max_times), dim=-1)


### PR DESCRIPTION
Update CVRPTW generator scaling to properly scale locations

## Description

This pull request modifies the scaling mechanism of the CVRPTW generator. 

## Motivation and Context

The previous implementation applied a uniform scaling factor (max_time) to both spatial (location) and temporal (time window) coordinates, which did not accurately reflect the distinct nature of these dimensions. The updated approach introduces separate scaling factors for locations and time windows.

 `close #258 ` 

- [✅ ] I have raised an issue to propose this change ([required](https://github.com/ai4co/rl4co/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.