### PR TITLE
Ensure baseline for SymNCO is always "symnco" when loading from checkpoint

### DIFF
--- a/rl4co/models/zoo/symnco/model.py
+++ b/rl4co/models/zoo/symnco/model.py
@@ -140,3 +140,27 @@ class SymNCO(REINFORCE):
 
         metrics = self.log_metrics(out, phase, dataloader_idx=dataloader_idx)
         return {"loss": out.get("loss", None), **metrics}
+
+    @classmethod
+    def load_from_checkpoint(
+        cls,
+        checkpoint_path,
+        map_location=None,
+        hparams_file=None,
+        strict=False,
+        load_baseline=True,
+        **kwargs,
+    ):
+        if kwargs.pop("baseline", "symnco") != "symnco":
+            log.warning(
+                "SymNCO only supports custom-symnco baseline. Setting to 'symnco'."
+            )
+        kwargs["baseline"] = "symnco"
+        return super().load_from_checkpoint(
+            checkpoint_path,
+            map_location,
+            hparams_file,
+            strict,
+            load_baseline,
+            **kwargs,
+        )

--- a/rl4co/models/zoo/symnco/model.py
+++ b/rl4co/models/zoo/symnco/model.py
@@ -87,12 +87,13 @@ class SymNCO(REINFORCE):
         out = self.policy(td, self.env, phase=phase, num_starts=n_start)
 
         # Unbatchify reward to [batch_size, n_start, n_aug].
-        reward = unbatchify(out["reward"], (n_start, n_aug))
+        unbatch_dims = (n_aug, n_start)
+        reward = unbatchify(out["reward"], unbatch_dims)
 
         # Main training loss
         if phase == "train":
             # [batch_size, n_start, n_aug]
-            ll = unbatchify(out["log_likelihood"], (n_start, n_aug))
+            ll = unbatchify(out["log_likelihood"], unbatch_dims)
 
             # Calculate losses: problem symmetricity, solution symmetricity, invariance
             loss_ps = problem_symmetricity_loss(reward, ll) if n_start > 1 else 0
@@ -117,7 +118,7 @@ class SymNCO(REINFORCE):
 
                 # Reshape batch to [batch, n_start, n_aug]
                 if out.get("actions", None) is not None:
-                    actions = unbatchify(out["actions"], (n_start, n_aug))
+                    actions = unbatchify(out["actions"], unbatch_dims)
                     out.update(
                         {"best_multistart_actions": gather_by_index(actions, max_idxs)}
                     )

--- a/rl4co/models/zoo/symnco/model.py
+++ b/rl4co/models/zoo/symnco/model.py
@@ -86,7 +86,7 @@ class SymNCO(REINFORCE):
         # Evaluate policy
         out = self.policy(td, self.env, phase=phase, num_starts=n_start)
 
-        # Unbatchify reward to [batch_size, n_start, n_aug].
+        # Unbatchify reward to [batch_size, n_aug, n_start].
         unbatch_dims = (n_aug, n_start)
         reward = unbatchify(out["reward"], unbatch_dims)
 


### PR DESCRIPTION
Closes #254.

Further, the order of dimensions `(n_start, n_aug)` in `unbatchify()` in the `shared_step()` function was fixed to `(n_aug, n_start)` to be consistent with other models in the framework. Dimensions should be `[B, A, S]`, where `B` is the batch size, `A` the number of augmentations, and `S` the number of starts.