### PR TITLE
[Feat] update MDCPDP env #220

### DIFF
--- a/rl4co/models/nn/env_embeddings/init.py
+++ b/rl4co/models/nn/env_embeddings/init.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 from tensordict.tensordict import TensorDict
 
 from rl4co.models.nn.ops import PositionalEncoding
-from rl4co.utils.ops import cartesian_to_polar, batched_scatter_sum
+from rl4co.utils.ops import batched_scatter_sum, cartesian_to_polar
 
 
 def env_init_embedding(env_name: str, config: dict) -> nn.Module:
@@ -428,8 +428,8 @@ class MDCPDPInitEmbedding(nn.Module):
         self.init_embed_delivery = nn.Linear(node_dim, embed_dim, linear_bias)
 
     def forward(self, td):
-        num_depots = td["capacity"].size(-1)
-        depot, locs = td["locs"][..., 0:num_depots, :], td["locs"][..., num_depots:, :]
+        num_agents = td["capacity"].size(-1)
+        depot, locs = td["locs"][..., 0:num_agents, :], td["locs"][..., num_agents:, :]
         num_locs = locs.size(-2)
         pick_feats = torch.cat(
             [locs[:, : num_locs // 2, :], locs[:, num_locs // 2 :, :]], -1
@@ -565,6 +565,7 @@ class MTVRPInitEmbedding(VRPInitEmbedding):
         )
         return torch.cat((depot_embedding, node_embeddings), -2)
 
+
 class FLPInitEmbedding(nn.Module):
     def __init__(self, embed_dim: int):
         super().__init__()
@@ -574,6 +575,7 @@ class FLPInitEmbedding(nn.Module):
         hdim = self.projection(td["locs"])
         return hdim
 
+
 class MCPInitEmbedding(nn.Module):
     def __init__(self, embed_dim: int):
         super().__init__()
@@ -582,6 +584,5 @@ class MCPInitEmbedding(nn.Module):
     def forward(self, td: TensorDict):
         items_embed = self.projection_items(td["weights"].unsqueeze(-1))
         # sum pooling
-        membership_emb = batched_scatter_sum(items_embed, td["membership"].long())        
+        membership_emb = batched_scatter_sum(items_embed, td["membership"].long())
         return membership_emb
-    


### PR DESCRIPTION
# Fixes to MDCPDP env

These fixes are based on feedback from @Moonbohoon in #220 (which was due quite some time ago :sweat_smile: ) and updates to the parallel autoregressive counterpart of this environment in [PARCO](https://github.com/ai4co/parco).

Now `num_depot` is replaced with `num_agents`; each agent has its own starting node, which can be either in the same location (as in `single` depot) or with different locations (`multiple` depot). 


Below is an example to instantiate a model with the new env:

```python
import torch
from rl4co.utils.trainer import RL4COTrainer

from rl4co.envs.routing.mdcpdp.env import MDCPDPEnv, MDCPDPGenerator
from rl4co.models.zoo.am.policy import AttentionModelPolicy
from rl4co.models.nn.env_embeddings.init import MDCPDPInitEmbedding
from rl4co.models.nn.env_embeddings.context import MDCPDPContext

# Greedy rollouts over trained model
device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")

embed_dim = 128
policy = AttentionModelPolicy(
            env_name="mdcpdp",
            init_embedding=MDCPDPInitEmbedding(embed_dim),
            context_embedding=MDCPDPContext(embed_dim),
            embed_dim=embed_dim,
        ).to(device)


generator = MDCPDPGenerator(min_capacity=2, max_capacity=3, num_agents=10, num_loc=60, depot_mode="multiple") # or set to "single" for M agents with the same starting location
env_ar = MDCPDPEnv(generator, problem_mode="open")

td_gen_ar = env_ar.generator(26)
td_reset_ar = env_ar.reset(td_gen_ar.clone()).to(device)

# Inference
with torch.inference_mode():
    out_ar = policy(td_reset_ar.clone(), env_ar, decode_type="greedy")

# Plotting (untrained!)
actions_ar = out_ar["actions"]# .reshaape(td_init.shape[0], -1)
print("Average tour length: {:.2f}".format(-out_ar['reward'].mean().item()))
for i in range(2):
    print(f"Tour {i} length: {-out_ar['reward'][i].item():.2f}")
    env_ar.render(td_reset_ar[i], actions_ar[i].cpu())
```

