### PR TITLE
[Chore] modernize logger interface

### DIFF
--- a/rl4co/envs/routing/mdcpdp/generator.py
+++ b/rl4co/envs/routing/mdcpdp/generator.py
@@ -17,7 +17,7 @@ class MDCPDPGenerator(Generator):
     Args:
         num_loc: number of locations (customers)
         min_loc: minimum value for the location coordinates
-        max_loc: maximum value for the location coordinates, default is 150 insted of 1.0, will be scaled
+        max_loc: maximum value for the location coordinates, default is 150 instead of 1.0, will be scaled
         loc_distribution: distribution for the location coordinates
         num_agents: number of depots, each depot has one vehicle
         depot_mode: mode for the depot, either single or multiple
@@ -64,7 +64,7 @@ class MDCPDPGenerator(Generator):
 
         # Number of locations must be even
         if num_loc % 2 != 0:
-            log.warn(
+            log.warning(
                 "Number of locations must be even. Adding 1 to the number of locations."
             )
             self.num_loc += 1

--- a/rl4co/envs/routing/mpdp/generator.py
+++ b/rl4co/envs/routing/mpdp/generator.py
@@ -48,7 +48,7 @@ class MPDPGenerator(Generator):
 
         # Number of locations must be even
         if num_loc % 2 != 0:
-            log.warn(
+            log.warning(
                 "Number of locations must be even. Adding 1 to the number of locations."
             )
             self.num_loc += 1

--- a/rl4co/envs/routing/pdp/generator.py
+++ b/rl4co/envs/routing/pdp/generator.py
@@ -47,7 +47,7 @@ class PDPGenerator(Generator):
 
         # Number of locations must be even
         if num_loc % 2 != 0:
-            log.warn(
+            log.warning(
                 "Number of locations must be even. Adding 1 to the number of locations."
             )
             self.num_loc += 1

--- a/rl4co/models/zoo/l2d/policy.py
+++ b/rl4co/models/zoo/l2d/policy.py
@@ -45,7 +45,7 @@ class L2DPolicy(AutoregressivePolicy):
         **constructive_policy_kw,
     ):
         if len(constructive_policy_kw) > 0:
-            log.warn(f"Unused kwargs: {constructive_policy_kw}")
+            log.warning(f"Unused kwargs: {constructive_policy_kw}")
 
         if encoder is None:
             if stepwise_encoding:
@@ -113,7 +113,7 @@ class L2DAttnPolicy(AutoregressivePolicy):
         **constructive_policy_kw,
     ):
         if len(constructive_policy_kw) > 0:
-            log.warn(f"Unused kwargs: {constructive_policy_kw}")
+            log.warning(f"Unused kwargs: {constructive_policy_kw}")
 
         if encoder is None:
             if init_embedding is None:

--- a/rl4co/models/zoo/nargnn/policy.py
+++ b/rl4co/models/zoo/nargnn/policy.py
@@ -68,7 +68,7 @@ class NARGNNPolicy(NonAutoregressivePolicy):
         **constructive_policy_kw,
     ):
         if len(constructive_policy_kw) > 0:
-            log.warn(f"Unused kwargs: {constructive_policy_kw}")
+            log.warning(f"Unused kwargs: {constructive_policy_kw}")
 
         if encoder is None:
             encoder = NARGNNEncoder(


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
Test it with:
```python
from rl4co.utils.pylogger import get_pylogger
log = get_pylogger(__name__)
log.warn("this is a test")
```
## Motivation and Context

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.